### PR TITLE
Add project roadmap documentation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,67 @@
+# Roadmap
+
+This document outlines what the **edh-deckbuilding-slots** project delivers today (MVP) and where it is headed in future releases.
+
+---
+
+## MVP — Minimum Viable Product
+
+The MVP is a deliberately narrow slice: a working CLI tool that lets a user organize a 100-card Commander decklist into named categories using the "slots" model.
+
+### Core features
+
+- **Commander slot** — Every decklist has exactly one mandatory fixed slot in its own category for the commander.
+- **User-defined categories** — Users create named categories (e.g., "Ramp," "Removal," "Draw") with 1--99 slots each.
+- **Exclusive slot assignment** — Each card occupies exactly one slot in one category. The total slot count across all categories equals 100.
+- **Pre-configured starter categories** — The app ships with optional category suggestions (Lands, Ramp, Removal, Draw, Enablers, Payoffs) that the user can adopt, modify, or ignore.
+
+### Interface and I/O
+
+- **Linux CLI** — The only supported interface is a command-line application running on Linux.
+- **Flat text file storage** — Decklists are read from and written to plain text files (no database).
+- **Plain text export** — Export format is `$QUANTITY $CARDNAME` (e.g., `1 Sol Ring`), one entry per line.
+
+### Intentional omissions
+
+- **No semantic validation** — The app does not check whether a card is legal, whether a sorcery was placed in a "Lands" category, or whether the commander is actually a legendary creature. Any string can go in any slot.
+
+---
+
+## Future Releases
+
+Features below are organized by theme. No specific release schedule is attached; they will be prioritized as the project matures.
+
+### Additional fixed slots
+
+- **Partner commanders** — Support for the partner mechanic, allowing two commanders.
+- **Background** — A fixed slot for the Background enchantment (paired with a "choose a Background" commander).
+- **Companion** — A fixed slot for a companion creature that lives outside the main 100.
+
+### Non-exclusive categories
+
+- Allow a card to appear in **multiple** category slots simultaneously (e.g., a card that is both "Ramp" and "Draw").
+- Each card must still have one **primary** category slot; additional appearances are marked as secondary.
+- The app visually distinguishes primary vs. secondary placements.
+- Total slot count may exceed 100 when non-exclusive mode is active.
+
+### Export formats
+
+- **CSV export** — Export decklists as CSV files.
+- **Third-party tool compatibility** — Export in formats recognized by Archidekt, Moxfield, and other popular deckbuilding platforms.
+
+### Scryfall integration
+
+- Pull card data (art, oracle text, legality, pricing, etc.) from the [Scryfall API](https://scryfall.com/docs/api) as an optional enrichment layer.
+- Core decklist operations remain fully **offline-capable** — Scryfall data is never required to add or remove cards.
+- When enabled, the app **warns** (does not error) if:
+  - A card name is not found in the Scryfall database.
+  - A card is found but is not legal in the Commander format.
+
+### Storage
+
+- **Database-backed persistence** — Replace or supplement flat text files with a local database for richer querying and history.
+
+### Platform and interface
+
+- **GUI** — A graphical interface (toolkit TBD).
+- **Non-Linux targets** — macOS and Windows support.


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive roadmap document that outlines the project's current MVP scope and future development direction.

## Changes
- **Added `docs/ROADMAP.md`** — A new roadmap document that clearly delineates:
  - **MVP features**: CLI tool for organizing 100-card Commander decklists into named category slots, with a mandatory commander slot and exclusive card assignment
  - **Interface & I/O**: Linux CLI support with flat text file storage and plain text export format
  - **Intentional omissions**: Explicitly notes that semantic validation (card legality, format rules) is out of scope for the MVP
  - **Future roadmap**: Organized by theme, including partner commanders, non-exclusive categories, additional export formats, Scryfall integration, database persistence, and GUI/platform expansion

## Implementation Details
The roadmap is structured to provide clarity on project boundaries and priorities:
- MVP section focuses on the narrow, working slice needed for initial release
- Future releases are grouped thematically rather than by timeline, allowing flexible prioritization
- Scryfall integration is explicitly designed to remain optional and offline-capable
- Clear distinction between what is intentionally excluded from MVP vs. what is planned for future versions

https://claude.ai/code/session_017DCV8DBFddztaGic1iccyd