### PR TITLE
feat: add Basic Lands fixed category to decklist model

### DIFF
--- a/src/deckslots/models.py
+++ b/src/deckslots/models.py
@@ -24,6 +24,7 @@ class Category:
     total_slots: int
     fixed: bool = False
     capped: bool = True
+    # Whitelist; enforced by future add_card method.
     allowed_cards: frozenset[str] | None = None
     cards: list[str] = field(default_factory=list)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,6 +11,20 @@ from deckslots.commands import (
 )
 
 
+def _make_session_with_deck():
+    """Create a session with an active decklist for testing."""
+    session = Session()
+    cmd = ParsedCommand(
+        kind="object_verb",
+        raw="decklist create TestDeck",
+        obj="decklist",
+        verb="create",
+        args=["TestDeck"],
+    )
+    handle_decklist_create(session, cmd)
+    return session
+
+
 class TestSession:
     """Session holds the active state for a REPL session."""
 
@@ -56,21 +70,9 @@ class TestDecklistCreateHandler:
 class TestCategoryCreateHandler:
     """handle_category_create adds a category to the active decklist."""
 
-    def _make_session_with_deck(self):
-        session = Session()
-        cmd = ParsedCommand(
-            kind="object_verb",
-            raw="decklist create TestDeck",
-            obj="decklist",
-            verb="create",
-            args=["TestDeck"],
-        )
-        handle_decklist_create(session, cmd)
-        return session
-
     def test_category_create_handler_adds_category(self):
         """The handler adds a category to the active decklist."""
-        session = self._make_session_with_deck()
+        session = _make_session_with_deck()
         cmd = ParsedCommand(
             kind="object_verb",
             raw="category create Ramp 10",
@@ -98,7 +100,7 @@ class TestCategoryCreateHandler:
 
     def test_category_create_rejects_non_numeric_slots(self):
         """The handler returns an error for non-numeric slot count."""
-        session = self._make_session_with_deck()
+        session = _make_session_with_deck()
         cmd = ParsedCommand(
             kind="object_verb",
             raw="category create Ramp abc",
@@ -111,7 +113,7 @@ class TestCategoryCreateHandler:
 
     def test_category_create_rejects_zero_slots_via_handler(self):
         """The handler surfaces the model validation error for 0 slots."""
-        session = self._make_session_with_deck()
+        session = _make_session_with_deck()
         cmd = ParsedCommand(
             kind="object_verb",
             raw="category create Ramp 0",
@@ -212,21 +214,9 @@ class TestCategoryListHandler:
 class TestBasicLandsInOutput:
     """Basic Lands category appears in listing and show output."""
 
-    def _make_session_with_deck(self):
-        session = Session()
-        cmd = ParsedCommand(
-            kind="object_verb",
-            raw="decklist create TestDeck",
-            obj="decklist",
-            verb="create",
-            args=["TestDeck"],
-        )
-        handle_decklist_create(session, cmd)
-        return session
-
     def test_category_list_includes_basic_lands(self):
         """category list output includes Basic Lands."""
-        session = self._make_session_with_deck()
+        session = _make_session_with_deck()
         cmd = ParsedCommand(
             kind="object_verb",
             raw="category list",
@@ -239,7 +229,7 @@ class TestBasicLandsInOutput:
 
     def test_decklist_show_includes_basic_lands(self):
         """decklist show output includes Basic Lands."""
-        session = self._make_session_with_deck()
+        session = _make_session_with_deck()
         cmd = ParsedCommand(
             kind="object_verb",
             raw="decklist show",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -173,7 +173,7 @@ class TestDecklistCreate:
         assert commander.fixed is True
 
     def test_total_slots_for_new_decklist_is_one(self):
-        """A new decklist has 1 total slot (the commander)."""
+        """A new decklist has 1 total slot (commander=1, basic lands=0)."""
         deck = Decklist.create("Test Deck")
         assert deck.total_slots == 1
 


### PR DESCRIPTION
## Summary
- Add mandatory "Basic Lands" fixed category to every new decklist, with 0 starting slots, uncapped upper limit, and a whitelist of 12 valid basic land names
- Add `capped` and `allowed_cards` fields to `Category` to support uncapped/restricted categories without subclassing
- Change `Category.cards` from `set[str]` to `list[str]` to allow duplicate card names (needed for basic lands)
- Define `BASIC_LAND_NAMES` frozenset constant (5 classics + Wastes + 6 snow-covered)

## Test plan
- [x] 20 new tests across `test_models.py` and `test_commands.py` (81 total, all passing)
- [x] Existing tests updated for `set` → `list` migration (2 assertions)
- [x] Lock-in tests verify `add_category` rejects duplicate "Basic Lands" name
- [x] Lock-in tests verify `category list` and `decklist show` include Basic Lands
- [x] Ruff lint and format checks pass
- [x] Strict TDD: 12 granular commits (red/green/refactor visible in git log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)