### PR TITLE
docs: update CLAUDE.md to reflect Basic Lands category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ edh-deckbuilding-slots/
 The app uses an **object-verb command pattern** with a dispatch registry:
 
 - **`cli.py`** — `parse_command(line)` returns a `ParsedCommand` with `kind` (`builtin`, `object_verb`, `unknown`, `empty`), `obj`, `verb`, and `args`. Known objects: `decklist`, `category`. Builtins: `quit`, `exit`, `help`.
-- **`models.py`** — Domain models. `Category` (name, total_slots, fixed, cards) and `Decklist` (name, categories dict). `Decklist.create()` auto-adds a mandatory Commander category.
+- **`models.py`** — Domain models. `Category` (name, total_slots, fixed, capped, allowed_cards, cards) and `Decklist` (name, categories dict). `Decklist.create()` auto-adds mandatory Commander and Basic Lands categories. `BASIC_LAND_NAMES` is a module-level `frozenset[str]` of all 12 valid basic land names. `Category.cards` is `list[str]` (allows duplicates for basic lands). Capped categories validate `1 <= total_slots <= 99`; uncapped categories validate `total_slots >= 0` with no upper limit. Uncapped categories return `None` for `available` and `False` for `is_full`.
 - **`commands.py`** — `Session` holds REPL state (`decklist: Decklist | None`). Handler functions (e.g., `handle_decklist_create`) return strings. `register_all_handlers(session)` builds a `dict[tuple[str, str], Callable]` dispatch registry. `dispatch(cmd, registry)` routes commands.
 - **`repl.py`** — `run_repl()` creates a Session and registry, loops on `input()`, delegates to dispatch for object-verb commands and `handle_help` for the help builtin.
 
@@ -112,13 +112,15 @@ uv run deckslots             # Run the app (console script)
 
 - **EDH / Commander**: A multiplayer Magic: The Gathering format using 100-card singleton decks led by a legendary creature (the "commander").
 - **Slot**: A single position in a decklist that expects to have a card associated with it. A slot is instantiated *before* any card is assigned to it (i.e., an empty slot is valid).
-- **Category**: A named grouping of one or more slots (e.g., "Ramp," "Removal," "Draw"). Categories are configured by the user with 1–99 slots each.
-- **Fixed slot**: A slot with a special structural role in the deck. The commander slot (with its own category) is mandatory. *(Roadmap: partner, background, and companion are optional pre-configured fixed slots.)*
+- **Category**: A named grouping of slots (e.g., "Ramp," "Removal," "Draw"). User-created categories are *capped* (1–99 slots). Categories can also be *uncapped* (0+ slots, no upper limit), used for Basic Lands.
+- **Fixed category**: A category with a special structural role in the deck, created automatically by `Decklist.create()`. The Commander category (1 fixed slot) and the Basic Lands category (0 starting slots, uncapped) are both mandatory.  *(Roadmap: partner, background, and companion are optional pre-configured fixed slots.)*
+- **Basic Lands**: A fixed, uncapped category restricted to the 12 valid basic land names (5 classics, Wastes, 6 snow-covered) via `allowed_cards`. Unlike normal categories, Basic Lands allows duplicate card names and has no upper slot limit. Enforcement of the `allowed_cards` whitelist is deferred to a future `add_card` method.
 - **Exclusivity**: In the MVP, categories and slots are *exclusive* — a card occupies exactly one slot in one category. *(Roadmap: when exclusivity is toggled off, a card may appear in multiple slots/categories, but must have a designated **primary** category slot. The app distinguishes primary vs. non-primary appearances. Non-exclusive mode allows the total slot count to exceed 100.)*
 
 ## MVP Scope
 
 - **One commander slot** — exactly 1 mandatory fixed slot in its own category.
+- **Basic Lands category** — mandatory fixed category, uncapped (0+ slots), restricted to 12 basic land names, allows duplicates.
 - **Exclusive categories only** — each card occupies exactly one slot in one category; total slots = 100.
 - **CLI on Linux** — local-only, no remote deployment.
 - **Flat text file I/O** — `$QUANTITY $CARDNAME` format (e.g., `1 Sol Ring`).


### PR DESCRIPTION
## Summary
- Update Architecture section to document new Category fields (capped, allowed_cards), list-based cards, BASIC_LAND_NAMES constant, and uncapped behavior
- Update Key Domain Concepts with Basic Lands entry and revised Category/Fixed category definitions
- Add Basic Lands to MVP Scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)