### PR TITLE
docs: user story 003 and plan — card move, remove, delete

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -37,8 +37,9 @@ Three objects, each with standard CRUD verbs plus domain-specific operations:
 | Command | Description |
 |---|---|
 | `card add <card-name> <category>` | Add a card to a category (fills one slot); fails if category is full or card already exists in decklist |
-| `card remove <card-name>` | Remove a card from wherever it is (frees one slot) |
-| `card move <card-name> <category>` | Move a card to a different category (fails if target is full) |
+| `card remove <card-name>` | Soft-remove: move card from its current category to the Uncategorized holding area; creates Uncategorized if absent; fails if card is already in Uncategorized |
+| `card move <card-name> <category>` | Move a card from its current category to a different one (fails if target is full, does not exist, or equals Uncategorized) |
+| `card delete <card-name>` | Hard-delete: permanently remove a card from the decklist; does not place it in Uncategorized |
 | `card list [category]` | List all cards, or only cards in the given category |
 
 ### REPL built-in commands
@@ -94,9 +95,17 @@ class Decklist:
 
     # Card operations
     def add_card(self, card_name: str, category_name: str) -> None: ...
-    def remove_card(self, card_name: str) -> None: ...
-    def move_card(self, card_name: str, target_category: str) -> None: ...
     def find_card(self, card_name: str) -> Category | None: ...
+        # Returns the first Category that contains card_name, or None.
+    def remove_card(self, card_name: str) -> str: ...
+        # Find and remove card from its category; return the source category
+        # name. Raises ValueError if not found. Removes only one occurrence
+        # (relevant for uncapped categories with duplicate card names).
+    def move_card(self, card_name: str, target_category: str) -> None: ...
+        # Validate target (exists, allowed_cards, capacity), then atomically
+        # remove from source and append to target. Does not call add_card
+        # internally so the singleton-exclusivity check is not re-applied
+        # against the source category.
 
     # Queries
     @property
@@ -169,17 +178,87 @@ Each numbered step is a Red-Green-Refactor cycle and gets its own commit(s).
 23. **`decklist rename`** handler.
 24. **Error feedback**: all domain errors (`ValueError`, `KeyError`, etc.) are caught and printed as user-friendly messages, never tracebacks.
 
-### Phase 5 — File I/O
+### Phase 5 — Card management (User Story 003)
 
-25. **`decklist export`**: write the decklist to a flat text file in `1 Card Name` format, grouped by category.
-26. **`decklist save`**: serialize decklist structure (categories, slot counts, card assignments) to a text/JSON file.
-27. **`decklist load`**: deserialize and restore a decklist from a saved file.
+#### Model additions (`src/deckslots/models.py`)
 
-### Phase 6 — Integration and polish
+25. **`Decklist.find_card`**: iterate `self.categories.values()`; return the
+    first `Category` whose `cards` list contains the card name, or `None`.
+    Tests: found in capped category, found in uncapped category, not found
+    returns `None`.
 
-28. **Wire dispatcher into `repl.py`**: replace the "Unknown command" catch-all with the real dispatcher; keep "Unknown command" as fallback for unrecognized input.
-29. **Update existing REPL tests**: ensure the existing 7 tests still pass (some may need adjustment since known commands will no longer be rejected).
-30. **End-to-end REPL test**: simulate a full session (create decklist → add categories → add cards → show → export) through mocked input/output.
+26. **`Decklist.remove_card`**: call `find_card`; raise `ValueError` if
+    `None`; call `cat.cards.remove(card)` (removes first occurrence); return
+    `cat.name`.
+    Tests: removes from capped category, removes only one copy from uncapped,
+    raises on missing card.
+
+27. **`Decklist.move_card`**: validate target exists, `allowed_cards`,
+    capacity; raise `ValueError` for each failure before mutating; then call
+    `source.cards.remove(card)` and `target.cards.append(card)`.
+    Do **not** call `add_card` internally (avoids spurious exclusivity failure
+    while card is still in source).
+    Tests: moves capped→capped, moves uncapped→capped (from Uncategorized),
+    raises if target full, raises if target not found, raises if same category,
+    raises if `allowed_cards` violated.
+
+#### Command handlers (`src/deckslots/commands.py`)
+
+28. **`handle_card_delete`**: require active decklist; join all `cmd.args` as
+    the card name; call `session.decklist.remove_card(card)`; return
+    `"Deleted '<card>' from the decklist."` on success or a user-friendly error
+    string on `ValueError`.
+    Tests: deletes from capped category, deletes from Uncategorized, error when
+    not found, error when no decklist, error when no args.
+
+29. **`handle_card_remove`**: require active decklist; join all `cmd.args` as
+    the card name; call `session.decklist.find_card(card)` first — if the card
+    is in Uncategorized, return an error directing the user to `card delete`;
+    call `session.decklist.remove_card(card)` to remove from its current
+    category; create the Uncategorized `Category` if `"uncategorized"` is not
+    already in `session.decklist.categories`; call
+    `session.decklist.add_card(card, "Uncategorized")`; return
+    `"Removed '<card>' from '<from-cat>'. Card is now in Uncategorized."`.
+    Tests: moves card to Uncategorized, creates Uncategorized if absent,
+    reuses existing Uncategorized, error if already in Uncategorized, error if
+    card not found, error if no decklist.
+
+30. **`_resolve_card_and_category`**: new helper — greedy longest-suffix match
+    for category. Iterate `i` from 1 to `len(args)-1`; join `args[i:]` and
+    check against `categories`; return `(" ".join(args[:i]), matched_key)` on
+    first (longest-suffix) match, or `None` if no match.
+    Tests: single-word category, multi-word category, no match returns `None`,
+    prefers longer category match over shorter.
+
+31. **`handle_card_move`**: require active decklist and at least 2 args; call
+    `_resolve_card_and_category`; return usage error if unresolved; check that
+    `target_cat.user_addable` is `True`, else return an error; call
+    `session.decklist.move_card(card, target_cat.name)`; return
+    `"Moved '<card>' from '<from-cat>' to '<to-cat>'."`.
+    Tests: basic move, move from Uncategorized to capped category, error if
+    card not found, error if target not found, error if target full, error if
+    targeting Uncategorized, error if already in target category, error if no
+    decklist.
+
+#### Registration and help
+
+32. **Register new handlers**: add `("card", "move")`, `("card", "remove")`,
+    and `("card", "delete")` to `register_all_handlers`.
+
+33. **Update `handle_help`**: add `card move`, `card remove`, and `card delete`
+    entries.
+
+### Phase 6 — File I/O
+
+34. **`decklist export`**: write the decklist to a flat text file in `1 Card Name` format, grouped by category.
+35. **`decklist save`**: serialize decklist structure (categories, slot counts, card assignments) to a text/JSON file.
+36. **`decklist load`**: deserialize and restore a decklist from a saved file.
+
+### Phase 7 — Integration and polish
+
+37. **Wire dispatcher into `repl.py`**: replace the "Unknown command" catch-all with the real dispatcher; keep "Unknown command" as fallback for unrecognized input.
+38. **Update existing REPL tests**: ensure the existing 7 tests still pass (some may need adjustment since known commands will no longer be rejected).
+39. **End-to-end REPL test**: simulate a full session (create decklist → add categories → add cards → move → remove → delete → show) through mocked input/output.
 
 ---
 
@@ -189,5 +268,7 @@ Each numbered step is a Red-Green-Refactor cycle and gets its own commit(s).
 2. **Case-insensitive command matching** for object and verb (`Category Create` works the same as `category create`). Card names preserve their original casing.
 3. **Category names may contain spaces** if we quote them or use a delimiter. For MVP simplicity: **single-word category names only** (e.g., `Ramp`, `Removal`, `Card-Draw`). Spaces in card names are handled by treating everything after the category argument as the card name, or vice versa.
 4. **Argument order for `card add`**: `card add <category> <card-name...>` — category first (single token), then card name (may contain spaces, consumes rest of line). This avoids the need for quoting card names.
-5. **Session state**: the REPL holds at most one `Decklist` at a time. `decklist create` replaces any existing decklist (with a confirmation prompt if one already exists). `decklist load` similarly replaces.
-6. **Save format**: JSON (simple, human-readable, stdlib `json` module). Export format remains `1 Card Name` per the MVP spec.
+5. **Argument order for `card move`**: `card move <card-name> <to-category>` — natural English order (move THING to PLACE). Because both card name and category can contain spaces, argument parsing uses `_resolve_card_and_category`, a greedy longest-suffix match helper that is the mirror of `_resolve_category_and_card`. The longest suffix of the arg list that matches a known category key is taken as the target; everything before it is the card name.
+6. **`card remove` vs `card delete`**: `card remove` is a soft operation (card goes to Uncategorized, persistent warning fires); `card delete` is a hard operation (card is gone). This distinction gives users a safety net: accidental removes are visible in Uncategorized and can be recovered with `card move`; intentional deletes are final.
+7. **Session state**: the REPL holds at most one `Decklist` at a time. `decklist create` replaces any existing decklist (with a confirmation prompt if one already exists). `decklist load` similarly replaces.
+8. **Save format**: JSON (simple, human-readable, stdlib `json` module). Export format remains `1 Card Name` per the MVP spec.

--- a/docs/user-stories/003-card-management.md
+++ b/docs/user-stories/003-card-management.md
@@ -1,0 +1,116 @@
+# User Story 003: Card Management — Move, Remove, and Delete
+
+## Story
+
+**As an** EDH deckbuilder,
+**I want to** move cards between categories, remove a card from its category back
+to an Uncategorized holding area, and permanently delete cards from the decklist,
+**so that** I can refine my deck without starting over.
+
+## Background
+
+Once a decklist is populated (whether by `card add` or `decklist import`), the
+user needs to reorganise cards as their thinking evolves. Three distinct
+operations cover the full lifecycle:
+
+- **Move** — reassign a card that already belongs to a category to a different
+  one (no holding area involved).
+- **Remove** — "unassign" a card from its category without deleting it; the card
+  lands in the Uncategorized holding area and the app nags the user to re-assign
+  it.
+- **Delete** — permanently remove a card from the decklist; it is not placed
+  anywhere.
+
+The Uncategorized holding area is fixed, uncapped, and not directly user-addable.
+It is created by `decklist import` (User Story 002) and can also be created on
+demand by `card remove` when it does not yet exist.
+
+## Acceptance Criteria
+
+### `card move <card-name> <to-category>`
+
+1. Moves the named card from wherever it currently lives to `<to-category>`.
+2. Returns an error if the card is not in the decklist.
+3. Returns an error if `<to-category>` does not exist.
+4. Returns an error if `<to-category>` is capped and has no available slots.
+5. Returns an error if `<to-category>` is Uncategorized (not directly
+   user-addable — use `card remove` instead).
+6. Returns an error if the card is already in `<to-category>`.
+7. Successfully moves a card FROM Uncategorized to a capped category that has
+   available slots.
+8. On success, prints:
+   ```
+   Moved '<card-name>' from '<from-category>' to '<to-category>'.
+   ```
+9. Multi-word card names are supported; argument parsing uses greedy
+   longest-suffix matching to resolve the target category (e.g.,
+   `card move Atraxa, Praetors' Voice Ramp` correctly identifies `Ramp` as the
+   target and `Atraxa, Praetors' Voice` as the card name).
+
+### `card remove <card-name>`
+
+10. Removes the named card from its current category and places it in the
+    Uncategorized holding category.
+11. If the Uncategorized category does not yet exist, it is created automatically
+    (fixed, uncapped, `user_addable=False`) before the card is added.
+12. Returns an error if the card is not in the decklist.
+13. Returns an error if the card is already in Uncategorized; suggests using
+    `card delete` to permanently remove it.
+14. On success, prints:
+    ```
+    Removed '<card-name>' from '<from-category>'. Card is now in Uncategorized.
+    ```
+15. After the operation, the persistent Uncategorized warning (already
+    implemented in the REPL from User Story 002) activates or increments.
+16. Multi-word card names are supported; all remaining args after `remove` are
+    joined as the card name.
+
+### `card delete <card-name>`
+
+17. Permanently removes the named card from the decklist, regardless of which
+    category it occupies (including Uncategorized).
+18. Returns an error if the card is not in the decklist.
+19. On success, prints:
+    ```
+    Deleted '<card-name>' from the decklist.
+    ```
+20. Does NOT place the card in Uncategorized; the card is gone entirely.
+21. Multi-word card names are supported (same as `card remove`).
+
+### General
+
+22. All three commands require an active decklist; return an error if none is
+    active.
+23. The persistent Uncategorized warning (shown before every command response
+    when Uncategorized is non-empty) is unaffected by `card move` and `card
+    delete` — it remains active as long as Uncategorized is non-empty. After
+    `card remove` the count in the warning increments.
+
+## Notes
+
+- `card move` is the primary mechanism for emptying Uncategorized after an
+  import: the user moves each card to its intended category.
+- `card remove` is intentionally a "soft" operation. Cards accumulate in
+  Uncategorized and the persistent nag encourages the user to act.
+- `card delete` is intentionally destructive. No confirmation prompt is shown
+  in the MVP — the user typed the command.
+- `card move` does **not** pass through an exclusivity check for the source
+  category when performing the move (the card is removed from the source before
+  being added to the target, so no duplicate-in-decklist violation can arise).
+  All other `add_card` validations — `allowed_cards` whitelist, slot capacity —
+  still apply.
+- The Uncategorized category created by `card remove` is identical in structure
+  to the one created by `decklist import`: fixed, uncapped, `user_addable=False`.
+  They are treated as the same category by the REPL.
+- `card remove` on a basic land in the Basic Lands category is permitted; the
+  land moves to Uncategorized (it is no longer in the `allowed_cards`-restricted
+  category). Moving it back out of Uncategorized via `card move` requires
+  targeting Basic Lands, which will enforce the `allowed_cards` whitelist.
+
+## Future Work (out of scope)
+
+- **Bulk move** — `card move all <to-category>` or move all Uncategorized cards
+  at once.
+- **Undo / history** — reverse the last operation.
+- **Conflict detection** — warn before `card delete` when the card is the only
+  occupant of a fixed category slot (e.g., deleting the commander).


### PR DESCRIPTION
Adds User Story 003 (card management: move, remove, delete) and updates
the implementation plan with new card commands, Decklist model methods
(find_card, remove_card, move_card), the _resolve_card_and_category
helper, Phase 5 TDD steps, and design decisions 5–6.

https://claude.ai/code/session_01UZHmFG9kBo4PtQyeZUJ3ML