### PR TITLE
docs: update ROADMAP to reflect shipped features

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,25 +1,30 @@
 # Roadmap
 
-This document outlines what the **edh-deckbuilding-slots** project delivers today (MVP) and where it is headed in future releases.
+This document outlines what the **edh-deckbuilding-slots** project delivers today and where it is headed in future releases.
 
 ---
 
-## MVP — Minimum Viable Product
+## Current Version
 
-The MVP is a deliberately narrow slice: a working CLI tool that lets a user organize a 100-card Commander decklist into named categories using the "slots" model.
+A working CLI tool that lets a user organize a 100-card Commander decklist into named categories using the "slots" model. The features below represent everything shipped to date.
 
 ### Core features
 
 - **Commander slot** — Every decklist has exactly one mandatory fixed slot in its own category for the commander.
+- **Partner commanders** — `decklist enable-partners` expands the Commander category to 2 slots, supporting the partner mechanic. Partners mode is persisted across save/load. *(User Story 008)*
 - **User-defined categories** — Users create named categories (e.g., "Ramp," "Removal," "Draw") with 1--99 slots each.
 - **Exclusive slot assignment** — Each card occupies exactly one slot in one category. The total slot count across all categories equals 100.
 - **Pre-configured starter categories** — The app ships with optional category suggestions (Lands, Ramp, Removal, Draw, Enablers, Payoffs) that the user can adopt, modify, or ignore.
+- **Card management** — `card add`, `card move`, `card remove`, and `card delete` let users add cards to categories, move them between categories, remove them from a category (returning them to Uncategorized), and delete them from the decklist entirely. *(User Story 003)*
+- **Rename** — `decklist rename` and `category rename` let users rename the active decklist or any user-defined category. *(User Story 007)*
+- **Consistency checks** — `decklist check` reports whether the decklist is valid: exactly 100 cards, no Uncategorized cards, Commander slot filled. *(User Story 006)*
 
 ### Interface and I/O
 
 - **Linux CLI** — The only supported interface is a command-line application running on Linux.
+- **Save and load** — `decklist save` persists the active decklist to disk; the app auto-resumes the last saved decklist on startup. *(User Story 004)*
 - **Decklist import** — `decklist import <file>` reads a plain text file in `$QUANTITY $CARDNAME` format with `Commander` and `Maindeck` section headings. The commander is routed to the Commander slot, basic lands to the Basic Lands category, and all other cards to a temporary **Uncategorized** category. The app persistently warns until Uncategorized is empty. *(User Story 002)*
-- **Plain text export** — `decklist export <filepath>` writes a Moxfield/Archidekt-compatible file with two sections: `Commander` (the assigned commander, if any) and `Maindeck` (all other cards, quantities aggregated, sorted alphabetically by card name). Category structure is intentionally discarded; external tools apply their own grouping and display logic. The export format is also compatible with `decklist import` (User Story 005).
+- **Plain text export** — `decklist export <filepath>` writes a Moxfield/Archidekt-compatible file with two sections: `Commander` (the assigned commander, if any) and `Maindeck` (all other cards, quantities aggregated, sorted alphabetically by card name). Category structure is intentionally discarded; external tools apply their own grouping and display logic. The export format is also compatible with `decklist import`. *(User Story 005)*
 
 ### Intentional omissions
 
@@ -33,7 +38,6 @@ Features below are organized by theme. No specific release schedule is attached;
 
 ### Additional fixed slots
 
-- **Partner commanders** — Support for the partner mechanic, allowing two commanders.
 - **Background** — A fixed slot for the Background enchantment (paired with a "choose a Background" commander).
 - **Companion** — A fixed slot for a companion creature that lives outside the main 100.
 
@@ -47,7 +51,7 @@ Features below are organized by theme. No specific release schedule is attached;
 ### Export formats
 
 - **CSV export** — Export decklists as CSV files.
-- **Third-party tool compatibility** — Export in formats recognized by Archidekt, Moxfield, and other popular deckbuilding platforms.
+- ~~**Third-party tool compatibility** — Export in formats recognized by Archidekt, Moxfield, and other popular deckbuilding platforms.~~ *(Covered by plain text export, which is already Moxfield/Archidekt-compatible.)*
 
 ### Scryfall integration
 

--- a/docs/user-stories/008-partner-commanders.md
+++ b/docs/user-stories/008-partner-commanders.md
@@ -1,0 +1,16 @@
+# User Story 008: Partner Commanders
+
+## Story
+
+**As an** EDH deckbuilder,
+**I want** `deckslots` to support partner commanders,
+**so that** I can brew decklists with those cards.
+
+## Acceptance Criteria
+
+- `decklist enable-partners` expands the Commander category from 1 slot to 2 slots.
+- The command can only be used when a decklist is active; if no decklist is active, the app shows an error.
+- Partners mode is reflected in `decklist show`: the Commander category displays `2/2 slots filled` when both slots are occupied.
+- Partners mode survives a save/load round-trip: after saving and reloading, the Commander category still has 2 slots and both commanders are present.
+- `decklist export` lists both commanders in the `Commander` section of the exported file.
+- Help text includes `decklist enable-partners`.


### PR DESCRIPTION
## Summary

- Renames the "MVP" section to "Current Version" with updated description
- Adds all features shipped since the original MVP write-up: card management (US-003), save/load (US-004), consistency checks (US-006), rename (US-007), and partner commanders (US-008)
- Removes partner commanders from Future Releases (now shipped)
- Strikes out the Archidekt/Moxfield third-party export item, since the existing plain text export already covers that use case
- Adds `docs/user-stories/008-partner-commanders.md` (retroactively documents the partners feature)

## Test plan

- [x] Read `docs/ROADMAP.md` and verify all shipped features are listed under "Current Version"
- [x] Confirm partner commanders no longer appears under Future Releases
- [x] Confirm Archidekt/Moxfield export item is struck through with explanation
- [x] Confirm `docs/user-stories/008-partner-commanders.md` exists and accurately describes the feature