### PR TITLE
docs: add v0.2.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] — 2026-03-08
+
+### Added
+
+- **US-007 — Rename Decklist and Categories**
+  - `decklist rename` prompts interactively for a new decklist name.
+  - `category rename <name>` prompts interactively for a new category name.
+    Only user-created categories can be renamed; fixed categories (Commander,
+    Basic Lands, Uncategorized) are protected.
+
+- **US-008 — Partner Commanders**
+  - `decklist enable-partners` expands the Commander slot to 2, allowing two
+    Partner commanders to be added.
+  - `decklist disable-partners` reverses the expansion, evacuating all
+    Commander cards to Uncategorized.
+
+- **US-009 — Background Commanders**
+  - `decklist enable-background` expands the Commander slot by 1 (to 2 by
+    default, to 3 if partners are also enabled), allowing a Background
+    co-commander alongside the main commander.
+  - `decklist disable-background` reverses the expansion, evacuating all
+    Commander cards to Uncategorized.
+  - Partners and Background modes are fully composable: enabling both gives
+    3 Commander slots.
+
+### Changed
+
+- **Save format simplified** (closes #42): the Commander section heading is
+  now always written as plain `Commander` (never `Commander [partners]`).
+  On load, Commander's slot count is set dynamically from the number of cards
+  present, providing full backwards compatibility with old save files.
+
+- **Persistent overcrowded warning**: after loading a save file whose
+  Commander section contains more cards than the current modes allow, a
+  warning is displayed after every command until the situation is resolved.
+
+### Refactored
+
+- Category model uses an ABC hierarchy (`Category` abstract base,
+  `CappedCategory`, `UncappedCategory` concrete classes) with a shared
+  `Protocol` for duck-typed usage, replacing the previous flat dataclass.
+
 ## [0.1.0] — 2026-02-28
 
 First public release. Ships the complete MVP: a Linux CLI for organising a


### PR DESCRIPTION
Adds the CHANGELOG entry for v0.2.1, covering US-007 (rename), US-008 (partners), US-009 (background commanders), and the save-format simplification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)