### PR TITLE
Add status line to deckslots CLI app

### DIFF
--- a/src/deckslots/repl.py
+++ b/src/deckslots/repl.py
@@ -17,7 +17,9 @@ from deckslots.commands import (
     validate_decklist_rename,
     validate_template_save,
 )
+from deckslots.config import is_validation_enabled
 from deckslots.logging_config import setup_logging
+from deckslots.status import render_status_line
 from deckslots.templates import user_template_exists
 
 _logger = logging.getLogger("deckslots.repl")
@@ -30,7 +32,6 @@ def _load_scryfall_index(session: Session) -> None:
     not a tty (non-interactive), silently skips.  In interactive mode with no
     cache the user is prompted once to download it.
     """
-    from deckslots.config import is_validation_enabled
     from deckslots.scryfall import (
         download_oracle_cards,
         get_cache_path,
@@ -88,6 +89,7 @@ def run_repl() -> None:
         try:
             session.decklist = _parse_save_file(str(save_path))
             click.echo(f"Resumed '{session.decklist.name}'.")
+            click.echo(render_status_line(session, is_validation_enabled()))
         except (OSError, ValueError) as e:
             _logger.warning("Save file load failed, entering recovery: %s", e)
             click.echo(f"Warning: could not load save file: {e}.")
@@ -201,6 +203,7 @@ def run_repl() -> None:
                 for w in reversed(warnings):
                     click.echo(click.style(w, fg="yellow", bold=True))
                 click.echo(result)
+                click.echo(render_status_line(session, is_validation_enabled()))
                 continue
             if parsed.kind == "unknown":
                 click.echo(f"Unknown command: {parsed.raw}")

--- a/src/deckslots/status.py
+++ b/src/deckslots/status.py
@@ -34,11 +34,15 @@ def render_status_line(session: Session, validation_enabled: bool) -> str:
         uncategorized = deck.categories.get("uncategorized")
         if uncategorized is not None and uncategorized.filled > 0:
             sections.append(
-                click.style(f"Uncategorized: {uncategorized.filled}", fg="yellow", bold=True)
+                click.style(
+                    f"Uncategorized: {uncategorized.filled}", fg="yellow", bold=True
+                )
             )
 
         if deck.commander_overcrowded:
-            sections.append(click.style("Commander overcrowded", fg="yellow", bold=True))
+            sections.append(
+                click.style("Commander overcrowded", fg="yellow", bold=True)
+            )
 
         if deck.companion_slot_empty:
             sections.append(click.style("Companion: empty", fg="yellow", bold=True))

--- a/src/deckslots/status.py
+++ b/src/deckslots/status.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import click
+
 from deckslots.commands import Session
 
 
@@ -12,4 +14,27 @@ def render_status_line(session: Session, validation_enabled: bool) -> str:
     overcrowded commander, empty companion slot, validation off) are styled
     yellow and bold via click.style().
     """
-    raise NotImplementedError
+    sections: list[str] = []
+
+    if session.decklist is None:
+        sections.append("No active decklist")
+    else:
+        deck = session.decklist
+        sections.append(f"{deck.name} ({deck.total_filled}/{deck.total_slots})")
+
+        uncategorized = deck.categories.get("uncategorized")
+        if uncategorized is not None and uncategorized.filled > 0:
+            sections.append(
+                click.style(f"Uncategorized: {uncategorized.filled}", fg="yellow", bold=True)
+            )
+
+        if deck.commander_overcrowded:
+            sections.append(click.style("Commander overcrowded", fg="yellow", bold=True))
+
+        if deck.companion_slot_empty:
+            sections.append(click.style("Companion: empty", fg="yellow", bold=True))
+
+    if not validation_enabled:
+        sections.append(click.style("Validation: OFF", fg="yellow", bold=True))
+
+    return " | ".join(sections)

--- a/src/deckslots/status.py
+++ b/src/deckslots/status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from deckslots.commands import Session
+from deckslots.models import CappedCategory
 
 
 def render_status_line(session: Session, validation_enabled: bool) -> str:
@@ -13,6 +14,9 @@ def render_status_line(session: Session, validation_enabled: bool) -> str:
     Sections are joined with ' | '.  Warning indicators (uncategorized cards,
     overcrowded commander, empty companion slot, validation off) are styled
     yellow and bold via click.style().
+
+    The filled count reflects only CappedCategory instances so that uncapped
+    holding areas (Basic Lands, Uncategorized) don't inflate the number.
     """
     sections: list[str] = []
 
@@ -20,7 +24,12 @@ def render_status_line(session: Session, validation_enabled: bool) -> str:
         sections.append("No active decklist")
     else:
         deck = session.decklist
-        sections.append(f"{deck.name} ({deck.total_filled}/{deck.total_slots})")
+        capped_filled = sum(
+            cat.filled
+            for cat in deck.categories.values()
+            if isinstance(cat, CappedCategory)
+        )
+        sections.append(f"{deck.name} ({capped_filled}/{deck.total_slots})")
 
         uncategorized = deck.categories.get("uncategorized")
         if uncategorized is not None and uncategorized.filled > 0:

--- a/src/deckslots/status.py
+++ b/src/deckslots/status.py
@@ -1,0 +1,15 @@
+"""Status line rendering for the deckslots REPL."""
+
+from __future__ import annotations
+
+from deckslots.commands import Session
+
+
+def render_status_line(session: Session, validation_enabled: bool) -> str:
+    """Return a compact one-line status string for the current session.
+
+    Sections are joined with ' | '.  Warning indicators (uncategorized cards,
+    overcrowded commander, empty companion slot, validation off) are styled
+    yellow and bold via click.style().
+    """
+    raise NotImplementedError

--- a/tests/functional/16-status-line.md
+++ b/tests/functional/16-status-line.md
@@ -1,0 +1,61 @@
+# Status Line
+
+The REPL displays a compact status line after every command showing the active
+decklist name, capped-slot fill progress, and any warning indicators.
+
+## Status line appears after decklist create
+
+```scrut
+$ printf 'decklist create TestDeck\nquit\n' | XDG_STATE_HOME="$TMPDIR" uv run deckslots
+deckslots> Welcome to deckslots.
+deckslots> Created decklist 'TestDeck'.
+TestDeck (0/1)
+deckslots> Goodbye.
+```
+
+## Status line updates slot count after category create
+
+```scrut
+$ printf 'decklist create TestDeck\ncategory create Ramp 10\nquit\n' | XDG_STATE_HOME="$TMPDIR" uv run deckslots
+deckslots> Welcome to deckslots.
+deckslots> Created decklist 'TestDeck'.
+TestDeck (0/1)
+deckslots> Created category 'Ramp' with 10 slots.
+TestDeck (0/11)
+deckslots> Goodbye.
+```
+
+## Status line shows compact Uncategorized warning alongside verbose warning
+
+```scrut
+$ printf "decklist import $TESTDIR/deck.txt\nquit\n" \
+>   | XDG_STATE_HOME="$TMPDIR" uv run deckslots
+deckslots> Welcome to deckslots.
+deckslots> Warning: 1 card(s) in Uncategorized. Assign them to categories before finalizing your decklist.
+Imported 'deck': 1 commander, 0 basic lands, 1 uncategorized cards.
+deck (1/1) | Uncategorized: 1
+deckslots> Goodbye.
+```
+
+## Status line shows Validation: OFF when validation disabled
+
+```scrut
+$ mkdir -p "$TMPDIR/conf_off/deckslots" \
+>   && printf '{"validation_enabled": false}' > "$TMPDIR/conf_off/deckslots/config.json" \
+>   && printf 'decklist create TestDeck\nquit\n' \
+>   | XDG_STATE_HOME="$TMPDIR" XDG_CONFIG_HOME="$TMPDIR/conf_off" uv run deckslots
+deckslots> Welcome to deckslots.
+deckslots> Created decklist 'TestDeck'.
+TestDeck (0/1) | Validation: OFF
+deckslots> Goodbye.
+```
+
+## Status line shows No active decklist before decklist is created
+
+```scrut
+$ printf 'decklist show\nquit\n' | XDG_STATE_HOME="$TMPDIR" uv run deckslots
+deckslots> Welcome to deckslots.
+deckslots> No active decklist. Use 'decklist create <name>' first.
+No active decklist
+deckslots> Goodbye.
+```

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -36,8 +36,11 @@ class TestSaveLoad:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Saved 'TestDeck'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -54,15 +57,20 @@ class TestSaveLoad:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Saved 'TestDeck'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Loaded 'TestDeck'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Decklist: TestDeck\n"
             "Total slots: 11 (0 filled)\n"
             "Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Ramp: 0/10 slots filled\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -71,6 +79,7 @@ class TestSaveLoad:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -79,6 +88,7 @@ class TestSaveLoad:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No saved decklist found.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -104,6 +114,7 @@ class TestAutoload:
         out = _run("quit\n", tmp_path)
         assert out == (
             "Resumed 'My Deck'.\n"
+            "My Deck (0/1)\n"
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Goodbye.\n"
         )
@@ -200,6 +211,7 @@ class TestExport:
             line
             for line in out.splitlines()
             if not line.startswith("deckslots> Exported")
+            and not line.startswith("TestDeck")
         ]
         assert lines == [
             "deckslots> Welcome to deckslots.",
@@ -244,6 +256,7 @@ class TestExport:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -252,7 +265,9 @@ class TestExport:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Usage: decklist export <filepath>\n"
+            "TestDeck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 

--- a/tests/test_repl_functional.py
+++ b/tests/test_repl_functional.py
@@ -113,6 +113,7 @@ class TestDecklist:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -121,11 +122,13 @@ class TestDecklist:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Decklist: TestDeck\n"
             "Total slots: 1 (0 filled)\n"
             "Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
+            "TestDeck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -134,6 +137,7 @@ class TestDecklist:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Usage: decklist create <name>\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -142,6 +146,7 @@ class TestDecklist:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -159,7 +164,9 @@ class TestCategories:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -168,6 +175,7 @@ class TestCategories:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -179,11 +187,14 @@ class TestCategories:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Ramp: 0/10 slots filled\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -203,8 +214,11 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Added 'Sol Ring' to 'Ramp'.\n"
+            "TestDeck (1/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -215,7 +229,9 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Added 'Forest' to 'Basic Lands'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -224,6 +240,7 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -244,8 +261,11 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Card 'Nonexistent' not found in the decklist.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -261,6 +281,7 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -279,7 +300,9 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Card 'Nonexistent' not found in the decklist.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -288,6 +311,7 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -300,9 +324,13 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Added 'Sol Ring' to 'Ramp'.\n"
+            "TestDeck (1/11)\n"
             "deckslots> Deleted 'Sol Ring' from the decklist.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -321,13 +349,18 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Added 'Sol Ring' to 'Ramp'.\n"
+            "TestDeck (1/11)\n"
             "deckslots> Deleted 'Sol Ring' from the decklist.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Ramp: 0/10 slots filled\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -336,6 +369,7 @@ class TestCards:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -357,12 +391,14 @@ class TestUncategorized:
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Imported 'deck': 1 commander, 0 basic lands, 1 uncategorized cards.\n"
+            "deck (1/1) | Uncategorized: 1\n"
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Categories:\n"
             "  Commander: 1/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Uncategorized: 1 slots filled (uncapped)\n"
+            "deck (1/1) | Uncategorized: 1\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -373,9 +409,11 @@ class TestUncategorized:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
+            "TestDeck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -390,15 +428,19 @@ class TestUncategorized:
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Imported 'deck': 1 commander, 0 basic lands, 1 uncategorized cards.\n"
+            "deck (1/1) | Uncategorized: 1\n"
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Created category 'Ramp' with 10 slots.\n"
+            "deck (1/11) | Uncategorized: 1\n"
             "deckslots> Moved 'Sol Ring' from 'Uncategorized' to 'Ramp'.\n"
+            "deck (2/11)\n"
             "deckslots> Categories:\n"
             "  Commander: 1/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Uncategorized: 0 slots filled (uncapped)\n"
             "  Ramp: 1/10 slots filled\n"
+            "deck (2/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -414,11 +456,14 @@ class TestUncategorized:
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Imported 'deck': 1 commander, 0 basic lands, 1 uncategorized cards.\n"
+            "deck (1/1) | Uncategorized: 1\n"
             "deckslots> Deleted 'Sol Ring' from the decklist.\n"
+            "deck (1/1)\n"
             "deckslots> Categories:\n"
             "  Commander: 1/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Uncategorized: 0 slots filled (uncapped)\n"
+            "deck (1/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -431,11 +476,15 @@ class TestUncategorized:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Added 'Sol Ring' to 'Ramp'.\n"
+            "TestDeck (1/11)\n"
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Removed 'Sol Ring' from 'Ramp'. Card is now in Uncategorized.\n"
+            "TestDeck (0/11) | Uncategorized: 1\n"
             "deckslots> Warning: 1 card(s) in Uncategorized. "
             "Assign them to categories before finalizing your decklist.\n"
             "Categories:\n"
@@ -443,6 +492,7 @@ class TestUncategorized:
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Ramp: 0/10 slots filled\n"
             "  Uncategorized: 1 slots filled (uncapped)\n"
+            "TestDeck (0/11) | Uncategorized: 1\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -476,9 +526,13 @@ class TestConsistency:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Added 'Sol Ring' to 'Ramp'.\n"
+            "TestDeck (1/11)\n"
             "deckslots> 'Sol Ring' is already in 'Ramp'. Nothing to do.\n"
+            "TestDeck (1/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -491,8 +545,11 @@ class TestConsistency:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Error: Basic lands can only be added to the 'Basic Lands' category.\n"  # noqa: E501
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -505,9 +562,13 @@ class TestConsistency:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Added 'Forest' to 'Basic Lands'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Error: Basic lands can only be added to the 'Basic Lands' category.\n"  # noqa: E501
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -537,12 +598,15 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> New name: Renamed decklist to 'My Commander Deck'.\n"
+            "My Commander Deck (0/1)\n"
             "deckslots> Decklist: My Commander Deck\n"
             "Total slots: 1 (0 filled)\n"
             "Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
+            "My Commander Deck (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -563,12 +627,16 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> New name: Renamed category 'Ramp' to 'Mana Rocks'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Mana Rocks: 0/10 slots filled\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -581,12 +649,16 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Mana Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> New name: Renamed category 'Mana Ramp' to 'Acceleration Package'.\n"  # noqa: E501
+            "TestDeck (0/11)\n"
             "deckslots> Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Acceleration Package: 0/10 slots filled\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -599,6 +671,7 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Cannot rename fixed category 'Commander'.\n"
             "deckslots> Goodbye.\n"
         )
@@ -612,6 +685,7 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Category 'nonexistent' not found.\n"
             "deckslots> Goodbye.\n"
         )
@@ -623,6 +697,7 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Usage: category rename <name>\n"
             "deckslots> Goodbye.\n"
         )
@@ -637,14 +712,20 @@ class TestRename:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
+            "TestDeck (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "TestDeck (0/11)\n"
             "deckslots> New name: Renamed category 'Ramp' to 'Mana Rocks'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Saved 'TestDeck'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Loaded 'TestDeck'.\n"
+            "TestDeck (0/11)\n"
             "deckslots> Categories:\n"
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Mana Rocks: 0/10 slots filled\n"
+            "TestDeck (0/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -665,14 +746,19 @@ class TestPartners:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'PartnerDeck'.\n"
+            "PartnerDeck (0/1)\n"
             "deckslots> Partners mode enabled. The Commander category now has 2 slots.\n"  # noqa: E501
+            "PartnerDeck (0/2)\n"
             "deckslots> Added 'Malcolm, Keen-Eyed Navigator' to 'Commander'.\n"
+            "PartnerDeck (1/2)\n"
             "deckslots> Added 'Tana, the Bloodsower' to 'Commander'.\n"
+            "PartnerDeck (2/2)\n"
             "deckslots> Decklist: PartnerDeck\n"
             "Total slots: 2 (2 filled)\n"
             "Categories:\n"
             "  Commander: 2/2 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
+            "PartnerDeck (2/2)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -681,6 +767,7 @@ class TestPartners:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -718,14 +805,19 @@ class TestBackground:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'BgDeck'.\n"
+            "BgDeck (0/1)\n"
             "deckslots> Background mode enabled. The Commander category now has 2 slots.\n"  # noqa: E501
+            "BgDeck (0/2)\n"
             "deckslots> Added 'Cloakwood Hermit' to 'Commander'.\n"
+            "BgDeck (1/2)\n"
             "deckslots> Added 'Criminal Past' to 'Commander'.\n"
+            "BgDeck (2/2)\n"
             "deckslots> Decklist: BgDeck\n"
             "Total slots: 2 (2 filled)\n"
             "Categories:\n"
             "  Commander: 2/2 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
+            "BgDeck (2/2)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -734,6 +826,7 @@ class TestBackground:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -758,13 +851,17 @@ class TestBackground:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'Hybrid'.\n"
+            "Hybrid (0/1)\n"
             "deckslots> Partners mode enabled. The Commander category now has 2 slots.\n"  # noqa: E501
+            "Hybrid (0/2)\n"
             "deckslots> Background mode enabled. The Commander category now has 3 slots.\n"  # noqa: E501
+            "Hybrid (0/3)\n"
             "deckslots> Decklist: Hybrid\n"
             "Total slots: 3 (0 filled)\n"
             "Categories:\n"
             "  Commander: 0/3 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
+            "Hybrid (0/3)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -798,8 +895,10 @@ class TestCompanion:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'LurrusDeck'.\n"
+            "LurrusDeck (0/1)\n"
             "deckslots> Companion slot enabled. "
             "Add a companion with 'card add Companion <card name>'.\n"
+            "LurrusDeck (0/2) | Companion: empty\n"
             "deckslots> Warning: Companion slot is empty. "
             "Add a companion with 'card add Companion <card name>'.\n"
             "Decklist: LurrusDeck\n"
@@ -808,6 +907,7 @@ class TestCompanion:
             "  Commander: 0/1 slots filled\n"
             "  Basic Lands: 0 slots filled (uncapped)\n"
             "  Companion: 0/1 slots filled\n"
+            "LurrusDeck (0/2) | Companion: empty\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -816,6 +916,7 @@ class TestCompanion:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> No active decklist. Use 'decklist create <name>' first.\n"
+            "No active decklist\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -1040,8 +1141,11 @@ class TestValidation:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'Test'.\n"
+            "Test (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "Test (0/11)\n"
             "deckslots> Added 'Sol Ring' to 'Ramp'.\n"
+            "Test (1/11)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -1077,7 +1181,9 @@ class TestValidation:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'Test'.\n"
+            "Test (0/1)\n"
             "deckslots> Added 'Forest' to 'Basic Lands'.\n"
+            "Test (0/1)\n"
             "deckslots> Goodbye.\n"
         )
 
@@ -1093,7 +1199,10 @@ class TestValidation:
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'Test'.\n"
+            "Test (0/1)\n"
             "deckslots> Created category 'Ramp' with 10 slots.\n"
+            "Test (0/11)\n"
             "deckslots> Added 'Gibberish Card' to 'Ramp'.\n"
+            "Test (1/11)\n"
             "deckslots> Goodbye.\n"
         )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -62,6 +62,14 @@ def test_slot_progress_updates_after_card_added():
     assert "(1/1)" in result
 
 
+def test_slot_progress_counts_only_capped_categories():
+    session = _session_with_deck("My Deck")
+    # Basic Lands is UncappedCategory; adding to it must not affect the filled count
+    session.decklist.add_card("Plains", "Basic Lands")
+    result = render_status_line(session, validation_enabled=True)
+    assert "(0/1)" in result  # not (1/1)
+
+
 # ---------------------------------------------------------------------------
 # Warning: uncategorized cards
 # ---------------------------------------------------------------------------

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -105,14 +105,12 @@ def test_overcrowded_warning_absent_when_not_overcrowded():
 
 def test_overcrowded_warning_shown_when_commander_overcrowded():
     session = _session_with_deck()
-    # Add two commanders to a 1-slot Commander category to trigger overcrowding
-    session.decklist.enable_partners()  # now 2 slots
-    session.decklist.add_card("Meren of Clan Nel Toth", "Commander")
-    session.decklist.add_card("Tevesh Szat, Doom of Fools", "Commander")
-    session.decklist.disable_partners()  # shrinks back to 1, evacuates to Uncategorized
-    # Now Commander is empty (cards evacuated), so not overcrowded — add one back via move
-    session.decklist.move_card("Meren of Clan Nel Toth", "Commander")
-    session.decklist.move_card("Tevesh Szat, Doom of Fools", "Commander")
+    # Directly append two cards to the 1-slot Commander category to force the
+    # overcrowded state (disable_partners evacuates cards, so cannot reach it
+    # via the normal API without then moving cards back in).
+    commander = session.decklist.categories["commander"]
+    commander.cards.append("Meren of Clan Nel Toth")
+    commander.cards.append("Tevesh Szat, Doom of Fools")
     result = render_status_line(session, validation_enabled=True)
     assert "Commander overcrowded" in result
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,3 @@
+"""Tests for deckslots.status — status line rendering."""
+
+from deckslots.status import render_status_line

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,3 +1,191 @@
 """Tests for deckslots.status — status line rendering."""
 
+import click
+
+from deckslots.commands import Session
+from deckslots.models import Decklist
 from deckslots.status import render_status_line
+
+
+def _session_with_deck(name: str = "Test Deck") -> Session:
+    session = Session()
+    session.decklist = Decklist.create(name)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# No active decklist
+# ---------------------------------------------------------------------------
+
+
+def test_no_decklist_shows_placeholder():
+    session = Session()
+    result = render_status_line(session, validation_enabled=True)
+    assert "No active decklist" in result
+
+
+def test_no_decklist_validation_off_shows_warning():
+    session = Session()
+    result = render_status_line(session, validation_enabled=False)
+    assert "Validation: OFF" in result
+
+
+def test_no_decklist_validation_on_omits_validation_section():
+    session = Session()
+    result = render_status_line(session, validation_enabled=True)
+    assert "Validation" not in result
+
+
+# ---------------------------------------------------------------------------
+# Active decklist — basic progress display
+# ---------------------------------------------------------------------------
+
+
+def test_shows_decklist_name():
+    session = _session_with_deck("Meren of Clan Nel Toth")
+    result = render_status_line(session, validation_enabled=True)
+    assert "Meren of Clan Nel Toth" in result
+
+
+def test_shows_slot_progress():
+    session = _session_with_deck("My Deck")
+    # Fresh deck: Commander (1 slot, 0 filled), Basic Lands (uncapped, 0 filled)
+    # total_slots counts only CappedCategory, so = 1; total_filled = 0
+    result = render_status_line(session, validation_enabled=True)
+    assert "(0/1)" in result
+
+
+def test_slot_progress_updates_after_card_added():
+    session = _session_with_deck("My Deck")
+    session.decklist.add_card("Meren of Clan Nel Toth", "Commander")
+    result = render_status_line(session, validation_enabled=True)
+    assert "(1/1)" in result
+
+
+# ---------------------------------------------------------------------------
+# Warning: uncategorized cards
+# ---------------------------------------------------------------------------
+
+
+def test_uncategorized_warning_absent_when_empty():
+    session = _session_with_deck()
+    result = render_status_line(session, validation_enabled=True)
+    assert "Uncategorized" not in result
+
+
+def test_uncategorized_warning_shown_when_cards_present():
+    session = _session_with_deck()
+    session.decklist.add_card("Meren of Clan Nel Toth", "Commander")
+    session.decklist.remove_card("Meren of Clan Nel Toth")  # moves to Uncategorized
+    result = render_status_line(session, validation_enabled=True)
+    assert "Uncategorized: 1" in result
+
+
+def test_uncategorized_warning_shows_correct_count():
+    session = _session_with_deck()
+    session.decklist.add_category("Spells", 10)
+    session.decklist.add_card("Lightning Bolt", "Spells")
+    session.decklist.add_card("Counterspell", "Spells")
+    session.decklist.remove_card("Lightning Bolt")
+    session.decklist.remove_card("Counterspell")
+    result = render_status_line(session, validation_enabled=True)
+    assert "Uncategorized: 2" in result
+
+
+# ---------------------------------------------------------------------------
+# Warning: commander overcrowded
+# ---------------------------------------------------------------------------
+
+
+def test_overcrowded_warning_absent_when_not_overcrowded():
+    session = _session_with_deck()
+    result = render_status_line(session, validation_enabled=True)
+    assert "overcrowded" not in result.lower()
+
+
+def test_overcrowded_warning_shown_when_commander_overcrowded():
+    session = _session_with_deck()
+    # Add two commanders to a 1-slot Commander category to trigger overcrowding
+    session.decklist.enable_partners()  # now 2 slots
+    session.decklist.add_card("Meren of Clan Nel Toth", "Commander")
+    session.decklist.add_card("Tevesh Szat, Doom of Fools", "Commander")
+    session.decklist.disable_partners()  # shrinks back to 1, evacuates to Uncategorized
+    # Now Commander is empty (cards evacuated), so not overcrowded — add one back via move
+    session.decklist.move_card("Meren of Clan Nel Toth", "Commander")
+    session.decklist.move_card("Tevesh Szat, Doom of Fools", "Commander")
+    result = render_status_line(session, validation_enabled=True)
+    assert "Commander overcrowded" in result
+
+
+# ---------------------------------------------------------------------------
+# Warning: companion slot empty
+# ---------------------------------------------------------------------------
+
+
+def test_companion_empty_warning_absent_when_companion_not_enabled():
+    session = _session_with_deck()
+    result = render_status_line(session, validation_enabled=True)
+    assert "Companion" not in result
+
+
+def test_companion_empty_warning_shown_when_enabled_but_empty():
+    session = _session_with_deck()
+    session.decklist.enable_companion()
+    result = render_status_line(session, validation_enabled=True)
+    assert "Companion: empty" in result
+
+
+def test_companion_empty_warning_absent_when_companion_filled():
+    session = _session_with_deck()
+    session.decklist.enable_companion()
+    session.decklist.add_card("Lutri, the Spellchaser", "Companion")
+    result = render_status_line(session, validation_enabled=True)
+    assert "Companion: empty" not in result
+
+
+# ---------------------------------------------------------------------------
+# Validation OFF indicator
+# ---------------------------------------------------------------------------
+
+
+def test_validation_off_shown_when_disabled():
+    session = _session_with_deck()
+    result = render_status_line(session, validation_enabled=False)
+    assert "Validation: OFF" in result
+
+
+def test_validation_on_omits_validation_section():
+    session = _session_with_deck()
+    result = render_status_line(session, validation_enabled=True)
+    assert "Validation" not in result
+
+
+# ---------------------------------------------------------------------------
+# Section separator
+# ---------------------------------------------------------------------------
+
+
+def test_sections_separated_by_pipe():
+    session = _session_with_deck()
+    session.decklist.enable_companion()  # triggers Companion: empty warning
+    result = render_status_line(session, validation_enabled=False)
+    # Should have both deck info and warning sections separated by " | "
+    assert " | " in result
+
+
+# ---------------------------------------------------------------------------
+# click.style: warning text is styled (non-empty when stripped of ANSI)
+# ---------------------------------------------------------------------------
+
+
+def test_uncategorized_warning_uses_click_style():
+    """The warning text should survive click.unstyle (i.e. is actually styled)."""
+    session = _session_with_deck()
+    session.decklist.add_card("Meren of Clan Nel Toth", "Commander")
+    session.decklist.remove_card("Meren of Clan Nel Toth")
+    result = render_status_line(session, validation_enabled=True)
+    plain = click.unstyle(result)
+    # The ANSI-stripped version should still contain the warning text
+    assert "Uncategorized: 1" in plain
+    # And the original should be longer (has ANSI codes)
+    assert len(result) > len(plain)


### PR DESCRIPTION
After every command, the REPL now displays a compact one-line status below the command output showing the active decklist's name, capped-slot fill progress, and any active warnings.

## Examples
```
TestDeck (0/11)
TestDeck (42/100) | Uncategorized: 3
TestDeck (99/100) | Companion: empty | Validation: OFF
No active decklist
```

## What's included

- New `status.py` module with `render_status_line(session, validation_enabled)` — renders the status string, joining sections with ` | ` and styling warning indicators yellow/bold via `click.style`
- Filled count reflects only `CappedCategory` instances, so uncapped holding areas (Basic Lands, Uncategorized) don't inflate the number
- Warning indicators: `Uncategorized: N` (cards needing assignment), `Commander overcrowded`, `Companion: empty`, `Validation: OFF`
- Falls back to `No active decklist` when no deck is loaded
- `repl.py` emits the status line via `click.echo` after every dispatched command
- New scrut functional test (`tests/functional/16-status-line.md`) covering the main scenarios end-to-end
- Full unit test coverage in `tests/test_status.py`; existing functional tests in `test_functional.py` and `test_repl_functional.py` updated to match the new output