### PR TITLE
Add project-specific skills for common AI agent workflows

### DIFF
--- a/.claude/skills/add-repl-command.md
+++ b/.claude/skills/add-repl-command.md
@@ -1,0 +1,119 @@
+---
+name: add-repl-command
+description: Use when adding a new object-verb REPL command to edh-deckbuilding-slots. Covers handler registration, help text, and the mandatory 01-startup.md update.
+---
+
+# Add a New REPL Command
+
+A project-local skill for adding a new `<object> <verb>` command following strict TDD.
+
+## When to Use
+
+- Adding any new command such as `category resize`, `card list`, `template apply`
+- Any change that adds a line to the output of `help`
+
+## Before You Start
+
+Identify before writing any code:
+
+- [ ] What are the object and verb? (e.g., `category` / `resize`)
+- [ ] Does the command need new model methods on `Decklist` or `Category`? If yes, run Phase 0 first.
+- [ ] Does it require a new entry in `handle_help()`? (Almost always yes — triggers `01-startup.md` update)
+
+---
+
+## Phase 0 — Model Changes (only if needed)
+
+Write failing pytest in `tests/test_models.py` → commit `test: ...`
+Implement in `src/deckslots/models.py` → commit `feat: ...`
+
+---
+
+## Phase 1 — Handler (TDD)
+
+### Step 1: Write failing scrut scenario
+
+Add a scenario to the appropriate `tests/functional/NN-topic.md` (create a new file if none fits). This test will fail until implementation is complete — that is the point.
+
+### Step 2: Write failing pytest for the handler
+
+Add a test class to `tests/test_commands.py`. Import the handler name **at the top of the file** — an `ImportError` at module level is a valid Red signal.
+
+```bash
+uv run pytest tests/test_commands.py -x
+```
+
+Expected: `ImportError` on the new handler name.
+
+### Step 3: Commit (Red)
+
+```
+test: failing tests for handle_<object>_<verb>
+```
+
+### Step 4: Implement the handler
+
+In `src/deckslots/commands.py`:
+- Add `handle_<object>_<verb>(session, cmd)` returning a `str`
+- Register in `register_all_handlers()` under `("<object>", "<verb>")`
+- Add to the help string in `handle_help()`
+
+```bash
+uv run pytest tests/test_commands.py -x
+```
+
+### Step 5: Commit (Green)
+
+```
+feat: handle_<object>_<verb> + dispatch registration
+```
+
+---
+
+## Phase 2 — Help Text and Documentation — MANDATORY
+
+### Step 6: Update `tests/functional/01-startup.md`
+
+**This step is mandatory and easy to forget.** The `help` scenario asserts the exact full help output. Any change to `handle_help()` breaks this test.
+
+Update the expected output to include the new command in the correct position (alphabetical within its object group: `card`, `category`, `decklist`, `template`).
+
+### Step 7: Update command grammar table
+
+In `src/deckslots/CLAUDE.md`, add a row to the correct command table under the appropriate `### X commands` section.
+
+---
+
+## Phase 3 — Full Suite
+
+### Step 8: Run the full suite
+
+```bash
+uv run pytest && scrut test --work-directory . tests/functional/
+```
+
+If `01-startup.md` fails, the help string in `handle_help()` and the scrut expected output are out of sync — fix both together.
+
+### Step 9: Commit
+
+```
+feat: <object> <verb> command — handler, help text, 01-startup.md, grammar table
+```
+
+---
+
+## Quick Reference
+
+| Step | File |
+|------|------|
+| Scrut scenario | `tests/functional/NN-topic.md` |
+| Handler + dispatch + help | `src/deckslots/commands.py` |
+| Handler tests | `tests/test_commands.py` |
+| Help output assertion | `tests/functional/01-startup.md` ← MANDATORY |
+| Grammar table | `src/deckslots/CLAUDE.md` |
+
+## Notes
+
+- Dispatch mechanics, `ParsedCommand` fields, command grammar → `src/deckslots/CLAUDE.md`
+- If the command adds a new mode lifecycle (`enable-X` / `disable-X`) → use the `implement-decklist-mode` skill instead
+- Argument parsing: `card add` uses longest-prefix match for category; `card move` uses longest-suffix match — do not assume positional args

--- a/.claude/skills/implement-decklist-mode.md
+++ b/.claude/skills/implement-decklist-mode.md
@@ -1,0 +1,185 @@
+---
+name: implement-decklist-mode
+description: Use when adding a new Commander mode (partner-style or companion-style) to edh-deckbuilding-slots. Covers model layer, command handlers, REPL warnings, save/load, and export/import changes.
+---
+
+# Implement a New Decklist Mode
+
+A project-local skill for implementing a new Commander mode following strict TDD. Use this for any feature that adds an `enable-X` / `disable-X` pair — Partners, Background, Companion, and future equivalents.
+
+## When to Use
+
+- Adding a new `decklist enable-X` / `decklist disable-X` command pair
+- Adding a new fixed category managed by enable/disable lifecycle
+
+## Before You Start
+
+### Answer these domain questions first
+
+Read `docs/domain-concepts.md` and answer before writing any code:
+
+- [ ] Is this a **slot expansion** (adds to `Commander.total_slots` like Partner/Background) or a **separate category** (creates a new `CappedCategory` like Companion)?
+- [ ] What does `disable_X()` do when cards are present? (Evacuate to Uncategorized)
+- [ ] What is the REPL warning condition? (Should be a new `@property` on `Decklist`)
+- [ ] What is the save format heading? (Plain word — `Companion`, not `Companion [1 slots]`)
+- [ ] Does the **export** format emit a new section? If yes, where? (Companion: between Commander and Maindeck)
+- [ ] Does this affect singleton exclusivity? (`UncappedCategory` is exempt; `CappedCategory` is not)
+
+### Check for an open user story
+
+```bash
+gh issue list --label user-story --state open
+```
+
+If none exists for this mode, use the `new-user-story` skill first.
+
+---
+
+## Phase 1 — Model Layer (TDD)
+
+### Step 1: Write failing pytest
+
+Add a test class to `tests/test_models.py` covering:
+- `enable_X()` sets the flag and updates the model correctly
+- `disable_X()` clears the flag and evacuates cards to Uncategorized
+- The new computed `@property` (e.g., `companion_slot_empty`)
+- Error cases (calling `enable_X()` when already enabled)
+
+Use `CappedCategory` or `UncappedCategory` in fixtures — never abstract `Category`.
+
+```bash
+uv run pytest tests/test_models.py -x
+```
+
+Expected: `AttributeError` — the methods do not exist yet.
+
+### Step 2: Commit (Red)
+
+```
+test: failing tests for enable_X / disable_X / X_property
+```
+
+### Step 3: Implement in `src/deckslots/models.py`
+
+- Add `X_enabled: bool = False` field to `Decklist`
+- Add `enable_X()` and `disable_X()` methods
+- Add computed `@property`
+- If creating a separate category: `CappedCategory("X", 1, fixed=True)`
+
+```bash
+uv run pytest tests/test_models.py -x
+```
+
+### Step 4: Commit (Green)
+
+```
+feat: enable_X / disable_X / X_enabled on Decklist
+```
+
+---
+
+## Phase 2 — Command Handlers (TDD)
+
+### Step 5: Write failing pytest
+
+Add test class to `tests/test_commands.py`. Import handler names **at the top of the file** — an `ImportError` at module level is a valid Red signal.
+
+```bash
+uv run pytest tests/test_commands.py -x
+```
+
+Expected: `ImportError` on the new handler names.
+
+### Step 6: Commit (Red)
+
+```
+test: failing tests for handle_decklist_enable_X / disable_X
+```
+
+### Step 7: Implement in `src/deckslots/commands.py`
+
+- Add `handle_decklist_enable_X(session, cmd)` and `handle_decklist_disable_X(session, cmd)`
+- Register both in `register_all_handlers()` under `("decklist", "enable-X")` and `("decklist", "disable-X")`
+- Add both to the help string in `handle_help()`
+
+```bash
+uv run pytest tests/test_commands.py -x
+```
+
+### Step 8: Commit (Green)
+
+```
+feat: handle_decklist_enable_X / disable_X + dispatch registration
+```
+
+---
+
+## Phase 3 — REPL Warning, Save/Load, Export/Import
+
+### Step 9: Add REPL warning (`src/deckslots/repl.py`)
+
+Add to the persistent warning block after every dispatch:
+
+```python
+if session.decklist is not None and session.decklist.X_property:
+    click.echo("Warning: ...")
+```
+
+### Step 10: Update save/load (`src/deckslots/commands.py`)
+
+- `_format_save_file`: emit the section heading and cards when mode is enabled
+- `_parse_save_file`: recognise the heading; restore the flag and category
+
+### Step 11: Update export/import (`src/deckslots/commands.py`) — only if mode has an export-visible section
+
+- `_format_export_file`: emit the section in the correct position
+- `_parse_import_file`: recognise the heading; route cards and enable the mode
+
+---
+
+## Phase 4 — Functional Tests
+
+### Step 12: Write scrut scenarios
+
+Create `tests/functional/NN-X-mode.md` covering:
+- `enable-X` happy path (category appears in `decklist show`)
+- `enable-X` without active decklist (error message)
+- `disable-X` evacuates cards to Uncategorized
+- Save/load round-trip preserves mode state
+- Export/import round-trip restores mode (if applicable)
+
+### Step 13: Update `tests/functional/01-startup.md` — MANDATORY
+
+The help output scenario asserts the exact full `help` text. Any change to `handle_help()` breaks this. Add the two new commands in the correct position (alphabetical within the `decklist` group).
+
+### Step 14: Run the full suite
+
+```bash
+uv run pytest && scrut test --work-directory . tests/functional/
+```
+
+### Step 15: Commit
+
+```
+feat: REPL warning, save/load, export/import, and functional tests for X mode
+```
+
+---
+
+## Quick Reference
+
+| Phase | Files |
+|-------|-------|
+| Model | `src/deckslots/models.py`, `tests/test_models.py` |
+| Handlers | `src/deckslots/commands.py`, `tests/test_commands.py` |
+| REPL warning | `src/deckslots/repl.py` |
+| Save/load | `src/deckslots/commands.py` (`_format_save_file`, `_parse_save_file`) |
+| Export/import | `src/deckslots/commands.py` (`_format_export_file`, `_parse_import_file`) |
+| Functional tests | `tests/functional/NN-X-mode.md`, `tests/functional/01-startup.md` |
+
+## Notes
+
+- Domain glossary and category rules → `docs/domain-concepts.md`
+- Dispatch mechanics, `ParsedCommand` fields → `src/deckslots/CLAUDE.md`
+- User story format → `new-user-story` skill
+- `move_card()` must NOT call `add_card()` internally — avoids spurious exclusivity failure while the card is still in the source category

--- a/.claude/skills/run-tests.md
+++ b/.claude/skills/run-tests.md
@@ -1,0 +1,73 @@
+---
+name: run-tests
+description: Use when running or interpreting tests for edh-deckbuilding-slots. Covers the two-framework split, single-file invocations, worktree caveat, and scrut format rules.
+---
+
+# Run Tests
+
+The project uses **two test frameworks** that must both pass before any commit.
+
+## Full Suite
+
+```bash
+uv run pytest && scrut test --work-directory . tests/functional/
+```
+
+Run this from the **main project directory** (see worktree caveat below).
+
+## pytest (unit/integration)
+
+```bash
+uv run pytest                                                                     # all tests
+uv run pytest -x                                                                  # stop on first failure (Red phase)
+uv run pytest tests/test_models.py                                                # single file
+uv run pytest tests/test_commands.py::TestDecklistEnableCompanion                 # single class
+uv run pytest tests/test_commands.py::TestDecklistEnableCompanion::test_returns_confirmation  # single test
+```
+
+## scrut (functional / black-box REPL)
+
+```bash
+scrut test --work-directory . tests/functional/                    # all scenarios
+scrut test --work-directory . tests/functional/13-companion.md     # single file
+```
+
+`--work-directory .` must point to the project root (the directory containing `pyproject.toml`).
+
+## Worktree Caveat
+
+If you are in a git worktree (`.worktrees/<branch>/`), **run pytest from the main project directory**, not the worktree — `uv` cache writes fail inside worktrees.
+
+```bash
+# Wrong — uv cache write fails:
+cd .worktrees/my-branch && uv run pytest
+
+# Correct — always from the main project directory:
+uv run pytest
+```
+
+The `_deckslots.pth` file at `.venv/lib/python3.12/site-packages/_deckslots.pth` must point to the **worktree's** `src/` while developing, and be restored to the main `src/` after PR creation.
+
+## Linting and Type Checking
+
+Run before any PR:
+
+```bash
+uv run ruff check .
+uv run ruff format .
+uv run ty check
+```
+
+## scrut Format Quick Reference
+
+- Each ` ```scrut ` block has exactly **one** `$ ` command (first line); all remaining lines are expected stdout
+- Use `$TMPDIR` subdirectories to isolate test cases that write save files
+- `$TMPDIR` is **not** expanded in expected output — filter variable paths with `| grep -v "pattern"`
+- When adding any new command, update `tests/functional/01-startup.md` (it asserts the full `help` output)
+
+## What Each Framework Covers
+
+| Framework | Tests |
+|-----------|-------|
+| pytest | Unit and integration: models, handlers, parsers |
+| scrut | Black-box REPL scenarios: full command flows, save/load round-trips |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ See [`docs/domain-concepts.md`](docs/domain-concepts.md) for the full glossary (
   ```
   New user stories must be created as GitHub Issues before implementation begins — see `.claude/skills/new-user-story.md` for the format.
 - **TDD is mandatory.** Do not skip the Red phase. Always start by writing the failing test before implementing production code.
+- **Project skills** in `.claude/skills/`: `new-user-story` (GitHub Issue format), `implement-decklist-mode` (Partner/Background/Companion pattern), `add-repl-command` (handler + 01-startup.md update), `run-tests` (pytest + scrut invocations, worktree caveat).
 - **Testing details** (test split, scrut format, naming conventions): see [`tests/CLAUDE.md`](tests/CLAUDE.md).
 - Use `uv run` to run commands; `uv add` / `uv add --dev` to manage dependencies.
 - Keep this file and its sub-`CLAUDE.md` files updated as the project evolves.


### PR DESCRIPTION
## Summary

- Add `.claude/skills/implement-decklist-mode.md` — TDD checklist for the Partner/Background/Companion 6-layer pattern (model → handlers → REPL warning → save/load → export/import → functional tests), with domain questions to answer before writing code
- Add `.claude/skills/add-repl-command.md` — checklist for new object-verb REPL commands, with an explicit MANDATORY flag on updating `tests/functional/01-startup.md` (the most commonly forgotten step)
- Add `.claude/skills/run-tests.md` — reference for both test frameworks (pytest + scrut), single-file invocations, and the worktree/uv-cache caveat
- Update `CLAUDE.md` Notes for AI Assistants to list all four project skills

## Test plan

- [ ] Skills are auto-discovered by the `Skill` tool in future sessions
- [ ] Each skill file has valid YAML frontmatter (`name`, `description`)
- [ ] Descriptions describe triggering conditions only (not workflow summaries)
- [ ] Skills cross-reference canonical docs rather than duplicating content

🤖 Generated with [Claude Code](https://claude.com/claude-code)