### PR TITLE
Add design docs for SQLite storage and PySide6 GUI with roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,9 +57,13 @@ Features below are organized by theme. No specific release schedule is attached;
 
 ### Storage
 
-- **Database-backed persistence** — Replace or supplement flat text files with a local database for richer querying and history.
+- **Database-backed persistence** — Replace or supplement flat text files with a local database for richer querying and history. Design: [`plans/2026-04-25-database-storage-design.md`](plans/2026-04-25-database-storage-design.md) (stdlib `sqlite3` at `$XDG_DATA_HOME/deckslots/library.db`; opt-in via `config.json`).
 
 ### Platform and interface
 
-- **GUI** — A graphical interface (toolkit TBD).
+- **GUI** — PySide6 desktop app, opt-in extra (`pip install deckslots[gui]`), launched via `deckslots gui`. Design: [`plans/2026-04-25-gui-pyside6-design.md`](plans/2026-04-25-gui-pyside6-design.md).
 - **Non-Linux targets** — macOS and Windows support.
+
+### Roadmap for Database + GUI
+
+See [`plans/2026-04-25-db-and-gui-roadmap.md`](plans/2026-04-25-db-and-gui-roadmap.md) for the phased ordering (shared service-layer + repository refactor → SQLite → GUI MVP → QoL → hardening).

--- a/docs/plans/2026-04-25-database-storage-design.md
+++ b/docs/plans/2026-04-25-database-storage-design.md
@@ -1,0 +1,140 @@
+# Design: Database-Backed Storage (Option A1)
+
+Replace the single-file plain-text save (`$XDG_STATE_HOME/deckslots/decklist.bak`)
+with a SQLite database at `$XDG_DATA_HOME/deckslots/library.db`, using only the
+stdlib `sqlite3` module. Plaintext `decklist import` / `decklist export` keep
+their Moxfield/Archidekt-compatible semantics unchanged.
+
+## Goals
+
+- Persist multiple decks (deck library) instead of one `decklist.bak`.
+- Persist mode flags (`partners_enabled`, `background_enabled`, `companion_enabled`)
+  explicitly rather than inferring from Commander card count.
+- Introduce a storage seam (`DecklistRepository`) that the GUI can reuse.
+- Zero new runtime dependencies.
+
+## Non-goals
+
+- Replacing plaintext `import` / `export`. Those are user-facing interop and stay.
+- Cross-deck queries beyond `list()`. Tagging, search, and history are deferred.
+- Concurrency. Single-process assumption; no file locking.
+
+## Schema (`schema_version = 1`)
+
+```sql
+CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT);
+
+CREATE TABLE decks (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  partners_enabled INTEGER NOT NULL DEFAULT 0,
+  background_enabled INTEGER NOT NULL DEFAULT 0,
+  companion_enabled INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE categories (
+  id INTEGER PRIMARY KEY,
+  deck_id INTEGER NOT NULL REFERENCES decks(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('capped', 'uncapped')),
+  fixed INTEGER NOT NULL,
+  user_addable INTEGER NOT NULL,
+  total_slots INTEGER,                    -- NULL for uncapped
+  position INTEGER NOT NULL,              -- preserves insertion order
+  UNIQUE (deck_id, name)
+);
+
+CREATE TABLE allowed_cards (
+  category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  card_name TEXT NOT NULL,
+  PRIMARY KEY (category_id, card_name)
+);
+
+CREATE TABLE cards (
+  id INTEGER PRIMARY KEY,
+  category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  position INTEGER NOT NULL                -- preserves list[str] order
+);
+CREATE INDEX cards_by_category ON cards (category_id, position);
+```
+
+`PRAGMA foreign_keys = ON` is enabled per connection. Migrations are hand-rolled
+in `storage.py`: a single `_migrate(conn)` function reads `schema_version` and
+applies each upgrade in order.
+
+## Architecture
+
+### New module: `src/deckslots/storage.py`
+
+```python
+class DecklistRepository(Protocol):
+    def save(self, deck: Decklist) -> int: ...           # returns deck id
+    def load(self, deck_id: int) -> Decklist: ...
+    def load_by_name(self, name: str) -> Decklist | None: ...
+    def list(self) -> list[DecklistSummary]: ...
+    def delete(self, deck_id: int) -> None: ...
+
+class PlaintextRepository(DecklistRepository): ...       # wraps existing _format_/_parse_save_file
+class SqliteRepository(DecklistRepository): ...          # new
+```
+
+`DecklistSummary` is `(id: int, name: str, total_filled: int, updated_at: str)`.
+
+### Migration on first run
+
+When `storage_backend = "sqlite"` is enabled and `library.db` does not exist:
+1. Create schema, write `schema_version = 1`.
+2. If a legacy `$XDG_STATE_HOME/deckslots/decklist.bak` exists, parse it via
+   `_parse_save_file` and `save()` it as the first deck. Leave the legacy file
+   in place (read-only fallback).
+
+### Wiring
+
+- `Session` (`commands.py:44–47`) gains `repository: DecklistRepository`.
+- `handle_decklist_save` / `handle_decklist_load` (`commands.py:592–614`) call
+  `session.repository.save(...)` / `.load_by_name(...)`.
+- `_format_save_file` / `_parse_save_file` move into `PlaintextRepository`
+  unchanged; `_format_export_file` / `_parse_import_file` stay in `commands.py`
+  (interop, not storage).
+- `config.py` adds `storage_backend: "plaintext" | "sqlite"`, default `"plaintext"`.
+- `repl.py:81–115` selects the repo from config at startup.
+
+### New CLI affordances (Phase 1.3)
+
+| Command | Description |
+|---|---|
+| `decklist list` | List decks in the library (id, name, total filled, updated_at) |
+| `decklist switch <name>` | Replace `Session.decklist` with the named deck |
+| `decklist delete <name>` | Remove a deck from the library (prompt to confirm) |
+
+## Testing strategy
+
+- **Repository contract** (`tests/test_storage_repository.py`): parametrized
+  over `PlaintextRepository` and `SqliteRepository`. Round-trips every fixed-mode
+  combination (none, partner, background, partner+background, companion +
+  each), asserting `Decklist` model equality after save→load.
+- **Schema migration**: test that opening a fresh DB applies version 1; opening
+  an already-migrated DB is a no-op.
+- **Legacy import**: fixture `decklist.bak` files load into SQLite and produce
+  byte-identical plaintext export.
+- **scrut**: existing functional suite must pass unchanged with default
+  `storage_backend = "plaintext"`; an additional functional run with
+  `storage_backend = "sqlite"` (env var override) covers save/load/list/switch.
+
+## Backwards compatibility
+
+- Default backend stays `"plaintext"`. Existing users see no change.
+- `storage_backend = "sqlite"` is opt-in via `config.json`.
+- Plaintext `decklist save <file>` / `decklist load <file>` continue to work
+  against arbitrary file paths regardless of backend (escape hatch).
+
+## Critical files
+
+- **New**: `src/deckslots/storage.py`, `tests/test_storage_repository.py`
+- **Modified**: `src/deckslots/commands.py` (Session, save/load handlers,
+  extract `_format_save_file`/`_parse_save_file` into `PlaintextRepository`),
+  `src/deckslots/repl.py` (startup chooses repo), `src/deckslots/config.py`
+  (storage_backend setting).

--- a/docs/plans/2026-04-25-db-and-gui-roadmap.md
+++ b/docs/plans/2026-04-25-db-and-gui-roadmap.md
@@ -1,0 +1,93 @@
+# Roadmap: Database + GUI Integration
+
+Order of work for shipping the database backend
+([2026-04-25-database-storage-design.md](2026-04-25-database-storage-design.md))
+and the PySide6 GUI ([2026-04-25-gui-pyside6-design.md](2026-04-25-gui-pyside6-design.md))
+without regressing the CLI.
+
+## Why this ordering
+
+Both features depend on the same two refactors: a **service layer**
+(extract domain operations from `commands.py` handlers) and a **repository
+seam** (`DecklistRepository` protocol). Doing those once, up front, means the
+DB and GUI work doesn't double up on plumbing.
+
+## Phases
+
+### Phase 0 — Shared refactors
+
+- **0.1** Extract `services.py` returning `CommandResult` / `DomainEvent`.
+  CLI handlers become 2–3 line adapters.
+- **0.2** Introduce `DecklistRepository` protocol in `storage.py` with a
+  `PlaintextRepository` wrapping the current `_format_save_file` /
+  `_parse_save_file`. Route `handle_decklist_save` / `handle_decklist_load`
+  through it.
+- **0.3** Gate: full pytest + scrut suites pass; zero user-visible change.
+
+### Phase 1 — SQLite backend
+
+- **1.1** `SqliteRepository` + schema migrations (see database design doc).
+- **1.2** Legacy `decklist.bak` import on first SQLite launch.
+- **1.3** Multi-deck CLI commands: `decklist list`, `decklist switch <name>`,
+  `decklist delete <name>`.
+- **1.4** `storage_backend = "sqlite"` opt-in via `config.json`; default stays
+  `"plaintext"`.
+
+Exit: power users can maintain a deck library; plaintext import/export still
+round-trips through Moxfield.
+
+### Phase 2 — GUI MVP
+
+- **2.1** PySide6 shell, deck board view, menu bar, repository-backed deck open.
+- **2.2** Drag-and-drop wired to `services.can_drop` / `services.move_card`,
+  with full validation feedback.
+- **2.3** Scryfall image pipeline (async fetch, on-disk cache, placeholder).
+- **2.4** Ship behind `[project.optional-dependencies] gui`. CLI install stays
+  slim.
+
+Exit: `deckslots gui` opens any deck the CLI can; drag-drop maintains all
+existing invariants.
+
+### Phase 3 — Quality of life
+
+- **3.1** Deck-library sidebar (uses `repository.list()`).
+- **3.2** Card search/typeahead from the Scryfall index, drag-from-search.
+- **3.3** Undo/redo built on a `DomainEvent` log persisted in a new `events`
+  table.
+- **3.4** Mana-curve / color-identity panel (cheap once cards are in SQL).
+
+### Phase 4 — Hardening
+
+- PyInstaller / AppImage packaging.
+- Perf pass for large basic-land sets and many categories.
+- Accessibility: keyboard-only drag alternative, screen-reader labels.
+
+## Decisions to confirm before Phase 1
+
+1. Default storage backend stays `plaintext` (lower risk) — Phase 1 is opt-in.
+2. Multi-deck CLI commands ship in Phase 1; the GUI is **not** the only
+   multi-deck UX.
+3. Scryfall image cache lives next to the existing oracle_cards cache under
+   `$XDG_CACHE_HOME/deckslots/`.
+
+## End-to-end verification
+
+- **After Phase 0**: `uv run pytest` + `scrut test tests/functional/` green.
+- **After Phase 1**: REPL → `decklist save` → `sqlite3 library.db .dump` shows
+  expected rows → `decklist load` → `decklist export` → file imports cleanly
+  into Moxfield.
+- **After Phase 2**: deck created in the REPL opens in the GUI; drag a card,
+  quit the GUI, reopen in the REPL; the move is reflected and plaintext export
+  is byte-identical except for the moved card.
+- **After Phase 3**: 100-card deck with images opens cold in < 2 s, warm cache
+  in < 500 ms.
+
+## Critical file map
+
+| Concern | New | Modified |
+|---|---|---|
+| Service layer | `src/deckslots/services.py`, `src/deckslots/events.py` | `src/deckslots/commands.py` (handlers shrink) |
+| Storage | `src/deckslots/storage.py` | `src/deckslots/commands.py:44–148`, `src/deckslots/repl.py:81–115`, `src/deckslots/config.py` |
+| Scryfall images | — | `src/deckslots/scryfall.py` |
+| GUI | `src/deckslots/gui/*` | `src/deckslots/cli.py` (gui subcommand), `pyproject.toml` (optional-deps) |
+| Tests | `tests/test_services.py`, `tests/test_storage_repository.py`, `tests/gui/*` | existing `test_commands.py` tests rewire onto services |

--- a/docs/plans/2026-04-25-gui-pyside6-design.md
+++ b/docs/plans/2026-04-25-gui-pyside6-design.md
@@ -1,0 +1,153 @@
+# Design: PySide6 GUI (Option B2)
+
+Add a desktop GUI on top of the existing CLI/REPL using PySide6 (Qt for Python,
+LGPL). The CLI stays the primary interface; the GUI is shipped as an opt-in
+extra (`pip install deckslots[gui]`) and launched via `deckslots gui`.
+
+## Goals
+
+- Visual deck board: categories as drop targets, cards with art.
+- Drag-and-drop between categories with full validation
+  (allowed_cards, fullness, singleton exclusivity).
+- Reuse the domain model and repository layer; no behaviour fork.
+
+## Non-goals
+
+- Replacing the REPL. The CLI keeps every command.
+- Web/remote access. Single-process desktop app.
+- Mobile/touch. Desktop-first.
+
+## Prerequisite: service layer
+
+The existing `handle_*` functions in `commands.py` mix domain mutation,
+Scryfall validation, and string formatting. Extract a thin service layer first:
+
+```python
+# src/deckslots/services.py  (new)
+@dataclass
+class CommandResult:
+    ok: bool
+    message: str
+    warnings: list[str]
+    events: list[DomainEvent]
+
+def add_card(deck: Decklist, card: str, category: str,
+             scryfall_index: dict | None) -> CommandResult: ...
+def move_card(deck: Decklist, card: str, to_category: str) -> CommandResult: ...
+def can_drop(deck: Decklist, card: str, to_category: str) -> bool: ...   # GUI preflight
+# ...one per user-facing operation
+```
+
+`DomainEvent` is an ADT (`CardAdded`, `CardMoved`, `CategoryCreated`, …) the
+GUI consumes to refresh views without a full re-render. CLI handlers shrink to
+a 2-3 line adapter that calls the service and stringifies the result.
+
+## Architecture
+
+```
+src/deckslots/
+├── services.py            # NEW — operations returning CommandResult
+├── events.py              # NEW — DomainEvent ADT
+└── gui/                   # NEW (loaded only when [gui] extra is installed)
+    ├── __init__.py
+    ├── app.py             # QApplication, main entry
+    ├── main_window.py     # Deck board, menu bar
+    ├── category_view.py   # QListView per category, drag/drop hooks
+    ├── card_model.py      # QAbstractListModel wrapping a Category.cards list
+    ├── card_inspector.py  # Right-pane card detail (image, type, legality)
+    ├── deck_library.py    # Sidebar listing decks via repository.list()
+    └── image_loader.py    # Async Scryfall image fetch + on-disk cache
+```
+
+`pyproject.toml` adds:
+```toml
+[project.optional-dependencies]
+gui = ["PySide6>=6.6", "Pillow>=10.0"]
+```
+
+`cli.py` adds a `gui` subcommand:
+```python
+@click.command()
+def gui():
+    """Launch the deckslots GUI."""
+    from deckslots.gui.app import run_app
+    run_app()
+```
+
+## Drag-and-drop
+
+- Each category is a `QListView` backed by `CardListModel(category)`.
+- Drop targets implement `canDropMimeData` → `services.can_drop(deck, card, target)`.
+- Illegal drop: red outline + tooltip with the rejection reason
+  (matches existing exception messages: "category is full",
+  "already in <category>", "card not allowed in this category").
+- Legal drop: emits `services.move_card(...)`, the resulting `CardMoved` event
+  triggers the source and target models to update.
+
+## Card images
+
+Extend `src/deckslots/scryfall.py`:
+
+- `get_image_cache_dir() -> Path` → `$XDG_CACHE_HOME/deckslots/card_images/`.
+- `fetch_card_image(name) -> Path` — uses `image_uris.normal` from the existing
+  oracle_cards index when available; falls back to `GET /cards/named?fuzzy=`.
+- Disk cache; in-memory `QPixmap` cache in `image_loader.py`.
+- All network work happens off the GUI thread (`QThreadPool`); placeholder
+  card-back image until the fetch lands. Respect Scryfall's 50–100 ms inter-request
+  guidance.
+
+## Wireframe
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│ deckslots — Goldfish Fundamentals                      [Deck▾] [Tools▾] [?]│
+├────────────────────────────────────────────────────────────────────────────┤
+│ Slots: 87/100 ● Uncategorized: 3 ⚠   [Partner:off] [Background:off] [Companion:off]│
+├──────────────────┬──────────────────┬──────────────────┬───────────────────┤
+│ COMMANDER (1/1) █│ RAMP (10/10)   █│ REMOVAL (8/10)  ▓│ CARD ADVANTAGE    │
+│  [card art]      │  [card] Sol Ring │  [card] Swords  │  (6/10)         ▒ │
+│  Atraxa, …       │  [card] Arcane S │  [card] Path    │  [card] Rhystic   │
+│                  │  [card] Nature's │  [card] Despark │  [card] Mystic R  │
+├──────────────────┼──────────────────┼──────────────────┼───────────────────┤
+│ BOARD WIPES (5/5)│ THREATS (15/15)█│ INTERACTION (4/5)│ UTILITY (3/5)   ▒ │
+├──────────────────┴──────────────────┴──────────────────┴───────────────────┤
+│ BASIC LANDS (uncapped: 34)   12× Island  10× Forest  8× Plains  4× Swamp   │
+├────────────────────────────────────────────────────────────────────────────┤
+│ UNCATEGORIZED ⚠ (3)   [card] Counterspell   [card] Cultivate   [card] D.T.│
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+`█ = full (green) · ▓ = near full · ▒ = open slots · ⚠ = needs attention`
+
+While dragging:
+- Legal target: green outline + `✓` badge.
+- Illegal target: red outline + tooltip with the exact rejection reason.
+- Cursor reverts to source on `Esc` or invalid drop.
+
+## Testing strategy
+
+- **Service-layer contract** (`tests/test_services.py`): every service function
+  has a unit test covering success, warnings, and rejection events. Existing
+  `test_commands.py` tests are rewritten to drive the service layer.
+- **GUI smoke** (`tests/gui/`): `pytest-qt` fixtures, drag/drop validation tests
+  against `services.can_drop`. UI rendering tested only at the model boundary
+  (model emits `dataChanged` after `CardMoved`).
+- **Image loader**: integration test with a fake HTTP server confirms cache hit
+  on second fetch.
+- **CLI regression**: existing pytest + scrut suites pass unchanged after the
+  service-layer refactor.
+
+## Out of scope for v1
+
+- Card search / typeahead (Phase 3).
+- Undo/redo (Phase 3, requires DB-backed event log).
+- Custom themes beyond Qt's default light/dark.
+- Packaging as AppImage/dmg/exe (Phase 4).
+
+## Critical files
+
+- **New**: `src/deckslots/services.py`, `src/deckslots/events.py`,
+  `src/deckslots/gui/*`, `tests/test_services.py`, `tests/gui/*`.
+- **Modified**: `src/deckslots/commands.py` (handlers shrink to service
+  adapters), `src/deckslots/scryfall.py` (image fetch + cache),
+  `src/deckslots/cli.py` (`gui` subcommand), `pyproject.toml` (optional-deps).


### PR DESCRIPTION
## Summary

This PR adds comprehensive design documentation for two major features: a SQLite-backed deck library storage system and a PySide6 desktop GUI. It also includes a phased roadmap for implementing both features without regressing the existing CLI.

## Changes

- **`docs/plans/2026-04-25-database-storage-design.md`** — Design for replacing single-file plaintext storage with SQLite at `$XDG_DATA_HOME/deckslots/library.db`. Covers:
  - Schema with `decks`, `categories`, `allowed_cards`, and `cards` tables
  - `DecklistRepository` protocol with `PlaintextRepository` and `SqliteRepository` implementations
  - Migration strategy for legacy `decklist.bak` files
  - Backwards-compatible opt-in via `config.json` (default stays plaintext)
  - Testing strategy using parametrized repository tests

- **`docs/plans/2026-04-25-gui-pyside6-design.md`** — Design for a PySide6 desktop GUI shipped as optional extra (`pip install deckslots[gui]`). Covers:
  - Visual deck board with drag-and-drop between categories
  - Full validation feedback (red/green outlines, tooltips for rejection reasons)
  - Async Scryfall image fetching with on-disk and in-memory caching
  - Service layer extraction (`CommandResult`, `DomainEvent` ADT) as prerequisite
  - Module structure under `src/deckslots/gui/`
  - Wireframe and testing strategy using `pytest-qt`

- **`docs/plans/2026-04-25-db-and-gui-roadmap.md`** — Phased implementation roadmap:
  - **Phase 0**: Shared refactors (service layer, repository protocol)
  - **Phase 1**: SQLite backend with multi-deck CLI commands
  - **Phase 2**: GUI MVP with drag-and-drop and image pipeline
  - **Phase 3**: Quality-of-life features (deck library sidebar, search, undo/redo)
  - **Phase 4**: Hardening (packaging, perf, accessibility)
  - End-to-end verification steps for each phase

- **`docs/ROADMAP.md`** — Updated to link to the new design documents and clarify storage/GUI implementation details

## Notable design decisions

- Both features depend on a shared **service layer** and **repository seam** to avoid duplication
- SQLite backend is **opt-in** (default stays plaintext) for backwards compatibility
- GUI is shipped as an **optional dependency** to keep CLI install slim
- Plaintext `import`/`export` semantics are preserved unchanged for Moxfield/Archidekt interop
- Zero new runtime dependencies for the database (uses stdlib `sqlite3`)
- Image caching respects Scryfall's rate-limiting guidance

https://claude.ai/code/session_01X85VgpF7D4hxGfQt5fqUZM