### PR TITLE
Reorganize CLI modules into cli/ subpackage

### DIFF
--- a/src/deckslots/CLAUDE.md
+++ b/src/deckslots/CLAUDE.md
@@ -4,12 +4,38 @@ The app uses an **object-verb command pattern** with a dispatch registry.
 
 > **GUI work?** The target design is in [`docs/design/design-handoff.md`](../../docs/design/design-handoff.md). Read that before implementing Phase 2. The hi-fi prototype (`docs/design/Big Bridge Energy.html`) is the visual target — open it in a browser.
 
-## cli.py
+## Module Layout
+
+CLI-facing modules live in the `cli/` subpackage; the top of `deckslots/` holds the domain model, services, persistence, and shared infrastructure.
+
+```
+src/deckslots/
+├── cli/                # CLI/REPL layer
+│   ├── __init__.py     # re-exports ParsedCommand, parse_command, main
+│   ├── parser.py       # ParsedCommand + parse_command + main (entry point)
+│   ├── commands.py     # Session, handlers, dispatch registry
+│   ├── repl.py         # run_repl loop
+│   └── status.py       # render_status_line
+├── models.py           # Decklist, Category, BASIC_LAND_NAMES
+├── services.py         # Pure domain functions → CommandResult
+├── events.py           # DomainEvent ADT
+├── storage.py          # DecklistRepository + PlaintextRepository
+├── templates.py        # Template, load/save/import/export
+├── scryfall.py         # Card-name validation index
+├── config.py           # config.json reader
+├── logging_config.py   # File logging setup
+└── exceptions.py       # DecklistError hierarchy
+```
+
+`pyproject.toml` keeps its `deckslots = "deckslots.cli:main"` entry point — `main` is re-exported from `cli/__init__.py`.
+
+## cli/parser.py
 
 - `parse_command(line)` returns a `ParsedCommand`
 - `ParsedCommand` fields: `kind` (`builtin`, `object_verb`, `unknown`, `empty`), `obj`, `verb`, `args`, `raw`, `builtin`
 - Known objects: `decklist`, `category`, `card`, `template`
 - Builtins: `quit`, `exit`, `help`
+- `main()` — console-script entry point (sets up logging, calls `run_repl`)
 
 ## models.py
 
@@ -63,18 +89,18 @@ Repository abstraction for deck persistence.
 - `_get_save_path()` — returns `$XDG_STATE_HOME/deckslots/decklist.bak` (falls back to `~/.local/state/`)
 - `_format_save_file(deck)` / `_parse_save_file(path)` — custom plain-text round-trip format (moved from `commands.py` in Phase 0)
 
-## commands.py
+## cli/commands.py
 
 - `Session` holds REPL state: `decklist: Decklist | None`, `scryfall_index: dict | None`, `repository: DecklistRepository` (defaults to `PlaintextRepository()`)
 - Handler functions (e.g., `handle_decklist_create`) return strings; domain handlers are thin adapters that call `services.*` and format the result
-- File I/O helpers (private, in commands.py):
+- File I/O helpers (private, in `cli/commands.py`):
   - `_format_export_file(decklist)` / `_parse_import_file(path)` — Moxfield/Archidekt-compatible format
 - `_resolve_category_and_card(args, categories)` — greedy longest-prefix match for `<category> <card>` args (used by `card add`)
 - `_resolve_card_and_category_suffix(args, categories)` — greedy longest-suffix match for `<card> <category>` args (used by `card move`)
 - `register_all_handlers(session)` — builds `dict[tuple[str, str], Callable]` dispatch registry covering decklist, category, card, and template handlers
 - `dispatch(cmd, registry)` — routes commands to the appropriate handler
 
-## repl.py
+## cli/repl.py
 
 - `run_repl()` — creates a Session and registry, then loops on `input()`:
   - On startup, loads/resumes the last saved decklist from XDG state home
@@ -298,4 +324,4 @@ class Decklist:
 9. **Export format**: up to three sections — `Commander`, `Companion` (only when a companion card is assigned), and `Maindeck` — compatible with Moxfield, Archidekt, and the `decklist import` command. Category structure is discarded. All non-commander, non-companion cards are merged into `Maindeck`, sorted alphabetically by card name.
 10. **Companion does not expand Commander**: Partner and Background both expand `Commander.total_slots`. Companion is a wholly separate `CappedCategory`; it does not affect Commander slot count or the `commander_overcrowded` check.
 11. **`cards` is a `list[str]`** (not a `set`): preserves insertion order and allows `UncappedCategory` to hold multiple copies of the same basic land. `CappedCategory` enforces singleton exclusivity at `add_card`/`move_card` time.
-12. **Save I/O in `storage.py`, export I/O in `commands.py`**: `_format_save_file` and `_parse_save_file` were moved to `storage.py` (Phase 0) and are used by `PlaintextRepository`. `_format_export_file` and `_parse_import_file` remain in `commands.py` (Moxfield/Archidekt-compatible format, not part of the repository abstraction).
+12. **Save I/O in `storage.py`, export I/O in `cli/commands.py`**: `_format_save_file` and `_parse_save_file` were moved to `storage.py` (Phase 0) and are used by `PlaintextRepository`. `_format_export_file` and `_parse_import_file` remain in `cli/commands.py` (Moxfield/Archidekt-compatible format, not part of the repository abstraction).

--- a/src/deckslots/cli/__init__.py
+++ b/src/deckslots/cli/__init__.py
@@ -1,0 +1,10 @@
+"""CLI subpackage for deckslots: parser, REPL, command handlers, status line.
+
+Re-exports the public surface so existing imports like
+``from deckslots.cli import ParsedCommand, parse_command, main`` continue to work
+and the ``pyproject.toml`` entry point ``deckslots.cli:main`` keeps resolving.
+"""
+
+from deckslots.cli.parser import ParsedCommand, main, parse_command
+
+__all__ = ["ParsedCommand", "main", "parse_command"]

--- a/src/deckslots/cli/commands.py
+++ b/src/deckslots/cli/commands.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Protocol
 
 from deckslots import services
-from deckslots.cli import ParsedCommand
+from deckslots.cli.parser import ParsedCommand
 from deckslots.exceptions import DecklistError, ParseError
 from deckslots.models import (
     BASIC_LAND_NAMES,
@@ -31,7 +31,7 @@ from deckslots.templates import (
     save_user_template,
 )
 
-logger = logging.getLogger("deckslots.commands")
+logger = logging.getLogger("deckslots.cli.commands")
 
 NO_ACTIVE_DECK = "No active decklist. Use 'decklist create <name>' first."
 
@@ -49,7 +49,6 @@ class Session:
 
 _CARD_LINE_RE = re.compile(r"^(\d+)\s+(.+)$")
 _SAVE_CAT_RE = re.compile(r"^(.+) \[(\d+) slots\]$")
-
 
 
 @dataclass

--- a/src/deckslots/cli/parser.py
+++ b/src/deckslots/cli/parser.py
@@ -37,8 +37,8 @@ def parse_command(line: str) -> ParsedCommand:
 @click.command()
 def main() -> None:
     """CLI entrypoint for deckslots."""
+    from deckslots.cli.repl import run_repl
     from deckslots.logging_config import setup_logging
-    from deckslots.repl import run_repl
 
     setup_logging()
     run_repl()

--- a/src/deckslots/cli/repl.py
+++ b/src/deckslots/cli/repl.py
@@ -3,8 +3,7 @@ import sys
 
 import click
 
-from deckslots.cli import parse_command
-from deckslots.commands import (
+from deckslots.cli.commands import (
     Session,
     dispatch,
     handle_category_rename,
@@ -15,12 +14,13 @@ from deckslots.commands import (
     validate_decklist_rename,
     validate_template_save,
 )
+from deckslots.cli.parser import parse_command
+from deckslots.cli.status import render_status_line
 from deckslots.config import is_validation_enabled
 from deckslots.logging_config import setup_logging
-from deckslots.status import render_status_line
 from deckslots.templates import user_template_exists
 
-_logger = logging.getLogger("deckslots.repl")
+_logger = logging.getLogger("deckslots.cli.repl")
 
 
 def _load_scryfall_index(session: Session) -> None:
@@ -191,8 +191,7 @@ def run_repl() -> None:
                     session.decklist is not None
                     and session.decklist.companion_slot_empty
                     and not (
-                        parsed.obj == "decklist"
-                        and parsed.verb == "enable-companion"
+                        parsed.obj == "decklist" and parsed.verb == "enable-companion"
                     )
                 ):
                     warnings.append(

--- a/src/deckslots/cli/status.py
+++ b/src/deckslots/cli/status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import click
 
-from deckslots.commands import Session
+from deckslots.cli.commands import Session
 from deckslots.models import CappedCategory
 
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -9,7 +9,7 @@ New REPL behaviors should get a scrut test; new handler/model behaviors get a py
 
 ## Test Organization
 
-- Mirror the source tree: `tests/test_cli.py` covers `src/deckslots/cli.py`, etc.
+- Mirror the source tree: `tests/test_cli.py` covers `src/deckslots/cli/parser.py`, `tests/test_commands.py` covers `src/deckslots/cli/commands.py`, etc.
 - File names: `test_<module>.py`; function names: `test_<expected_behavior>` (e.g. `test_deck_rejects_duplicate_cards`, not `test_deck_1`)
 - Only import names that already exist in production code — a top-level `ImportError` fails the **entire** test file.
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,7 +1,7 @@
 import pytest
 
 from deckslots.cli import ParsedCommand
-from deckslots.commands import (
+from deckslots.cli.commands import (
     Session,
     _format_export_file,
     _parse_import_file,
@@ -2394,7 +2394,7 @@ class TestHandleDecklistDisableCompanion:
 
 class TestDispatchedHandlerProtocol:
     def test_dispatched_handler_protocol_is_importable(self):
-        from deckslots.commands import DispatchedHandler  # noqa: F401
+        from deckslots.cli.commands import DispatchedHandler  # noqa: F401
 
 
 def _cmd(obj, verb, *args):
@@ -2687,7 +2687,7 @@ class TestCommandsLogging:
         import logging
 
         from deckslots.cli import ParsedCommand
-        from deckslots.commands import (
+        from deckslots.cli.commands import (
             Session,
             handle_card_add,
             handle_decklist_create,
@@ -2719,7 +2719,7 @@ class TestCommandsLogging:
         import logging
 
         from deckslots.cli import ParsedCommand
-        from deckslots.commands import (
+        from deckslots.cli.commands import (
             Session,
             handle_decklist_create,
             handle_decklist_save,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2703,7 +2703,7 @@ class TestCommandsLogging:
             session,
             _make_cmd("decklist create Test", "decklist", "create", ["Test"]),
         )
-        with caplog.at_level(logging.DEBUG, logger="deckslots.commands"):
+        with caplog.at_level(logging.DEBUG, logger="deckslots.cli.commands"):
             handle_card_add(
                 session,
                 _make_cmd(
@@ -2736,7 +2736,7 @@ class TestCommandsLogging:
             session,
             _make_cmd("decklist create Test", "decklist", "create", ["Test"]),
         )
-        with caplog.at_level(logging.DEBUG, logger="deckslots.commands"):
+        with caplog.at_level(logging.DEBUG, logger="deckslots.cli.commands"):
             handle_decklist_save(
                 session,
                 _make_cmd("decklist save", "decklist", "save", []),

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -2,9 +2,9 @@
 
 import click
 
-from deckslots.commands import Session
+from deckslots.cli.commands import Session
+from deckslots.cli.status import render_status_line
 from deckslots.models import Decklist
-from deckslots.status import render_status_line
 
 
 def _session_with_deck(name: str = "Test Deck") -> Session:


### PR DESCRIPTION
## Summary
Restructure the CLI layer by moving parser, commands, REPL, and status modules into a dedicated `cli/` subpackage. This improves code organization by clearly separating CLI concerns from the domain model and services.

## Key Changes

- **Created `src/deckslots/cli/` subpackage** with:
  - `__init__.py` — re-exports `ParsedCommand`, `parse_command`, and `main` to maintain backward compatibility
  - `parser.py` — moved from `src/deckslots/cli.py`; contains `ParsedCommand`, `parse_command()`, and `main()` entry point
  - `commands.py` — moved from `src/deckslots/commands.py`; contains `Session`, handler functions, and dispatch registry
  - `repl.py` — moved from `src/deckslots/repl.py`; contains `run_repl()` loop
  - `status.py` — moved from `src/deckslots/status.py`; contains `render_status_line()`

- **Updated all internal imports** across the codebase to reflect new module paths:
  - `from deckslots.cli import ParsedCommand` → `from deckslots.cli.parser import ParsedCommand`
  - `from deckslots.commands import ...` → `from deckslots.cli.commands import ...`
  - `from deckslots.repl import run_repl` → `from deckslots.cli.repl import run_repl`
  - `from deckslots.status import render_status_line` → `from deckslots.cli.status import render_status_line`

- **Updated logger names** to reflect new module hierarchy:
  - `deckslots.commands` → `deckslots.cli.commands`
  - `deckslots.repl` → `deckslots.cli.repl`

- **Maintained entry point compatibility**: `pyproject.toml` entry point `deckslots = "deckslots.cli:main"` continues to work via re-export from `cli/__init__.py`

- **Updated documentation** in `CLAUDE.md` with new module layout diagram and corrected references

## Implementation Details

- The `cli/__init__.py` re-exports public API (`ParsedCommand`, `parse_command`, `main`) to ensure existing imports and the console script entry point remain functional
- All test imports updated to use new paths (e.g., `from deckslots.cli.commands import Session`)
- Module docstring added to `cli/__init__.py` explaining the re-export pattern
- Minor formatting cleanup in `repl.py` (line continuation style)

https://claude.ai/code/session_01KysBW83NXrvy14KZqN8D4J