### PR TITLE
Add categorical git stash prohibition with automated enforcement

### DIFF
--- a/.claude/hooks/check_banned_git_ops.py
+++ b/.claude/hooks/check_banned_git_ops.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block banned git operations before they run."""
+
+import json
+import re
+import sys
+
+data = json.load(sys.stdin)
+cmd = data.get("tool_input", {}).get("command", "")
+
+# Strip heredoc bodies so "git stash" in commit message text doesn't trigger.
+scanned = re.sub(
+    r"<<['\"]?\w+['\"]?.*?^\w+",
+    "",
+    cmd,
+    flags=re.DOTALL | re.MULTILINE,
+)
+
+# "git stash" at a command boundary (start, after ; & | newline or open-paren).
+# Exclude "git config" lines (used to set the blocking alias itself).
+stash_invocation = re.search(
+    r"(?:^|[;&|(\n])\s*git\s+stash",
+    scanned,
+    re.MULTILINE,
+)
+
+if stash_invocation and "git config" not in scanned:
+    print("BLOCKED: git stash is prohibited in this project.")
+    print("To inspect committed state without stashing:")
+    print("  git show HEAD:<file> | uv run ruff check -")
+    print("  git diff HEAD -- <file>")
+    print("See CLAUDE.md: Forbidden git operations.")
+    sys.exit(2)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/check_banned_git_ops.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '--- Session reminder: re-read CLAUDE.md at the start of the next session (forbidden ops, TDD rules). ---'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,23 @@ scrut test --work-directory . tests/functional/  # Functional CLI tests
 - **Creating PRs**: Must be on the feature branch — `gh pr create` from `main` errors with "head branch is the same as base branch."
 - **Python style**: PEP 8, enforced by Ruff (E, F, I, W); line length 88.
 
+## Forbidden git operations
+
+These operations are **categorically banned** — no exceptions, no "safe probe" use cases:
+
+| Banned command | Why banned | Safe alternative |
+|----------------|-----------|-----------------|
+| `git stash` / `git stash pop` | Stash pop can fail on concurrent file changes (e.g. `uv.lock`), leaving work in an unrecoverable state | `git show HEAD:<path> \| uv run ruff check -` to lint the committed version; `git diff HEAD -- <path>` to see what changed |
+| `git reset --hard` | Discards uncommitted work permanently | `git stash` is banned, but `git restore <path>` is OK for single-file revert when you've confirmed the file is expendable |
+| `git push --force` to `main`/`master` | Overwrites shared history | Never force-push to main; force-push only to personal feature branches, and only with explicit user instruction |
+
+**Project enforcement:**
+- `.claude/settings.json` contains a `PreToolUse` hook that intercepts any Bash command matching `git stash` and exits 2 (blocked).
+- `.git/config` contains a `stash` alias that prints the prohibition and exits 1 (shell-level fallback).
+- Neither guard is committed to the repo — note them in dev setup if this project gains new contributors.
+
+**At session start:** Re-read this section before any git operations. The rule is categorical: if you are tempted to use a banned command, find the safe alternative listed above instead.
+
 ## Key Domain Concepts
 
 See [`docs/domain-concepts.md`](docs/domain-concepts.md) for the full glossary (slots, categories, fixed categories, basic lands, exclusivity, Uncategorized, and card-add business rules). Read it before planning any feature that touches business logic.


### PR DESCRIPTION
## Summary

- **`CLAUDE.md`**: New "Forbidden git operations" section with a table of categorically banned commands (`git stash`, `git reset --hard`, `git push --force` to main), their rationale, and safe alternatives (`git show HEAD:<file> | uv run ruff check -`, `git diff HEAD -- <file>`)
- **`.claude/hooks/check_banned_git_ops.py`**: PreToolUse hook script that intercepts any Bash command invoking `git stash` at a command boundary, prints the safe alternatives, and exits 2 (blocked). Strips heredoc bodies first to avoid false positives in commit messages
- **`.claude/settings.json`**: Wires the hook into Claude Code's PreToolUse event for Bash tool calls; also adds a Stop hook that prints a session-boundary reminder to re-read CLAUDE.md
- **`.git/config` (local, not committed)**: `stash` alias that overrides `git stash` at the shell level and exits 1 — shell-level fallback for non-Claude invocations

## Motivation

A `git stash` was used during a session to "safely" inspect pre-existing lint errors without changing the working tree. It felt like a read-only probe, but `git stash pop` subsequently failed on a concurrent `uv.lock` modification, requiring manual recovery. The prohibition existed in an AI-assistant note in CLAUDE.md but wasn't prominent or enforced. These changes make the ban categorical, document safe alternatives, and add two automated enforcement layers so the rule doesn't depend on willpower or memory.

## Test plan

- [ ] Confirm `git stash` in a Bash tool call is blocked and shows the alternatives message
- [ ] Confirm `git commit -m "$(cat <<'EOF'\n...git stash...\nEOF\n)"` is NOT blocked (heredoc false-positive regression)
- [ ] Confirm `git config alias.stash ...` is NOT blocked
- [ ] Confirm the Stop hook reminder prints at session end

https://claude.ai/code/session_01KysBW83NXrvy14KZqN8D4J

---
_Generated by [Claude Code](https://claude.ai/code/session_01KysBW83NXrvy14KZqN8D4J)_