### PR TITLE
Phase 1: SQLite backend + multi-deck CLI commands

### DIFF
--- a/src/deckslots/CLAUDE.md
+++ b/src/deckslots/CLAUDE.md
@@ -80,21 +80,24 @@ class CommandResult:
 
 Functions: `add_card`, `move_card`, `can_drop` (preflight predicate, returns `bool`), `remove_card`, `delete_card`, `create_category`, `resize_category`, `delete_category`, `rename_category`, `rename_decklist`, `enable_partners`, `disable_partners`, `enable_background`, `disable_background`, `enable_companion`, `disable_companion`, `apply_template`.
 
-## storage.py (Phase 0+)
+## storage.py (Phase 1+)
 
-Repository abstraction for deck persistence.
+Persistence layer that owns the storage seam.
 
-- `DecklistRepository` — `Protocol` with `save(deck)`, `load() -> Decklist | None`, `delete()`
-- `PlaintextRepository(path=None)` — wraps the custom plain-text save format; `path` defaults to `_get_save_path()` (XDG state home). Pass an explicit `path` in tests for isolation.
-- `_get_save_path()` — returns `$XDG_STATE_HOME/deckslots/decklist.bak` (falls back to `~/.local/state/`)
-- `_format_save_file(deck)` / `_parse_save_file(path)` — custom plain-text round-trip format (moved from `commands.py` in Phase 0)
+- `DecklistRepository` (Protocol) — 5 methods: `save(deck) -> int`, `load(deck_id) -> Decklist`, `load_by_name(name) -> Decklist | None`, `list() -> list[DecklistSummary]`, `delete(deck_id) -> None`
+- `DecklistSummary` — frozen dataclass `(id: int, name: str, total_filled: int, updated_at: str)` returned by `list()`
+- `PlaintextRepository(path=None)` — single-file backend at `$XDG_STATE_HOME/deckslots/decklist.bak`. Implements the protocol with a synthetic ID of 1; `list()` returns one summary if the file exists (tolerating parse errors so the REPL can detect corruption via `load()`).
+- `SqliteRepository(path=None)` — multi-deck backend at `$XDG_DATA_HOME/deckslots/library.db` (stdlib `sqlite3`, `PRAGMA foreign_keys = ON`). Schema migrations in `_migrate(conn)`; currently `schema_version = 1`. `save()` upserts by deck name; `_maybe_import_legacy()` seeds an empty db from any existing `decklist.bak`.
+- `_format_save_file(decklist)` / `_parse_save_file(path)` / `_get_save_path()` — plain-text format helpers (private; used by both repository implementations)
 
 ## cli/commands.py
 
-- `Session` holds REPL state: `decklist: Decklist | None`, `scryfall_index: dict | None`, `repository: DecklistRepository` (defaults to `PlaintextRepository()`)
+- `Session` holds REPL state: `decklist: Decklist | None`, `scryfall_index: dict | None`, `repository: DecklistRepository` (default-constructed `PlaintextRepository`)
 - Handler functions (e.g., `handle_decklist_create`) return strings; domain handlers are thin adapters that call `services.*` and format the result
-- File I/O helpers (private, in `cli/commands.py`):
-  - `_format_export_file(decklist)` / `_parse_import_file(path)` — Moxfield/Archidekt-compatible format
+- I/O helpers:
+  - Storage round-trip (`_format_save_file`, `_parse_save_file`, `_get_save_path`) lives in `storage.py` and is re-exported from `commands.py` for backward compatibility
+  - `_format_export_file(decklist)` / `_parse_import_file(path)` — Moxfield/Archidekt-compatible format (interop, stays in `commands.py`)
+- Multi-deck handlers route through `session.repository` (`handle_decklist_save/load/list/switch/delete`); `decklist delete` prompts via `click.confirm`
 - `_resolve_category_and_card(args, categories)` — greedy longest-prefix match for `<category> <card>` args (used by `card add`)
 - `_resolve_card_and_category_suffix(args, categories)` — greedy longest-suffix match for `<card> <category>` args (used by `card move`)
 - `register_all_handlers(session)` — builds `dict[tuple[str, str], Callable]` dispatch registry covering decklist, category, card, and template handlers
@@ -137,6 +140,17 @@ Repository abstraction for deck persistence.
 
 - `get_config_path()` → XDG-compliant path (`$XDG_CONFIG_HOME/deckslots/config.json`)
 - `is_validation_enabled()` → bool — reads `config.json`; defaults to True if absent
+- `get_storage_backend()` → `"plaintext"` (default) or `"sqlite"`; reads `config.json`; falls back to `"plaintext"` on missing/malformed config or unknown value
+
+## storage.py
+
+Persistence layer that owns the storage seam.
+
+- `DecklistRepository` (Protocol) — 5 methods: `save(deck) -> int`, `load(deck_id) -> Decklist`, `load_by_name(name) -> Decklist | None`, `list() -> list[DecklistSummary]`, `delete(deck_id) -> None`
+- `DecklistSummary` — frozen dataclass `(id: int, name: str, total_filled: int, updated_at: str)` returned by `list()`
+- `PlaintextRepository(path=None)` — single-file backend at `$XDG_STATE_HOME/deckslots/decklist.bak`. Implements the protocol with a synthetic ID of 1; `load()` ignores `deck_id` and `delete()` removes the file. `list()` returns one summary if the file exists (or `[]` otherwise), tolerating parse errors so the REPL can detect corruption via `load()`.
+- `SqliteRepository(path=None)` — multi-deck backend at `$XDG_DATA_HOME/deckslots/library.db` (stdlib `sqlite3`, `PRAGMA foreign_keys = ON`). Schema migrations are hand-rolled in `_migrate(conn)` — currently `schema_version = 1` with `decks`, `categories`, `allowed_cards`, `cards` tables (cards table has a `cards_by_category` index on `(category_id, position)`). `save()` upserts by deck name; `_maybe_import_legacy()` runs once on the first open of an empty db to seed it from any existing `decklist.bak` (the plaintext file is preserved as a read-only fallback).
+- `_format_save_file(decklist)` / `_parse_save_file(path)` / `_get_save_path()` — plain-text format helpers (private; used by both `PlaintextRepository` and the legacy import path)
 
 ## exceptions.py
 
@@ -172,6 +186,9 @@ All commands follow `<object> <verb> [arguments...]`.
 | `decklist export <filename>` | Export to Moxfield/Archidekt-compatible plain text file (Commander, optional Companion, Maindeck sections) |
 | `decklist save <filename>` | Save decklist structure to a file (categories, slots, cards) |
 | `decklist load <filename>` | Load decklist structure from a file |
+| `decklist list` | List all decks in the library (id, name, card count, last-updated date) |
+| `decklist switch <name>` | Replace the active deck with a saved deck by name |
+| `decklist delete <name>` | Remove a saved deck from the library (prompts to confirm) |
 | `decklist import <filename>` | Import a plain-text decklist (Commander/Companion/Maindeck headings); routes cards to Commander slot, Basic Lands, and Uncategorized |
 | `decklist enable-partner` | Expand Commander slot to 2 for the partner mechanic |
 | `decklist disable-partner` | Revert Commander to 1 slot; all Commander cards move to Uncategorized |
@@ -324,4 +341,5 @@ class Decklist:
 9. **Export format**: up to three sections — `Commander`, `Companion` (only when a companion card is assigned), and `Maindeck` — compatible with Moxfield, Archidekt, and the `decklist import` command. Category structure is discarded. All non-commander, non-companion cards are merged into `Maindeck`, sorted alphabetically by card name.
 10. **Companion does not expand Commander**: Partner and Background both expand `Commander.total_slots`. Companion is a wholly separate `CappedCategory`; it does not affect Commander slot count or the `commander_overcrowded` check.
 11. **`cards` is a `list[str]`** (not a `set`): preserves insertion order and allows `UncappedCategory` to hold multiple copies of the same basic land. `CappedCategory` enforces singleton exclusivity at `add_card`/`move_card` time.
-12. **Save I/O in `storage.py`, export I/O in `cli/commands.py`**: `_format_save_file` and `_parse_save_file` were moved to `storage.py` (Phase 0) and are used by `PlaintextRepository`. `_format_export_file` and `_parse_import_file` remain in `cli/commands.py` (Moxfield/Archidekt-compatible format, not part of the repository abstraction).
+12. **I/O is split by purpose**: persistent storage lives in `storage.py` (`PlaintextRepository`, `SqliteRepository`, plus the plain-text format helpers `_format_save_file` / `_parse_save_file` that they share). External interop — `_format_export_file` and `_parse_import_file` (Moxfield/Archidekt) — stays in `commands.py` because it is user-facing format conversion, not deck-library state. `commands.py` re-exports the storage helpers for backward compatibility.
+13. **Storage backend is opt-in**: the default is `PlaintextRepository` (single `decklist.bak`); users opt into `SqliteRepository` by setting `{"storage_backend": "sqlite"}` in `config.json`. Multi-deck commands (`decklist list/switch/delete`) work with either backend — Plaintext just sees a one-element library.

--- a/src/deckslots/cli/commands.py
+++ b/src/deckslots/cli/commands.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import os
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 

--- a/src/deckslots/cli/commands.py
+++ b/src/deckslots/cli/commands.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
-import re
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,9 +18,16 @@ from deckslots.models import (
     Decklist,
     UncappedCategory,
 )
-from deckslots.storage import (
+
+# Re-exported for backward compatibility with existing tests and repl.py imports.
+from deckslots.storage import (  # noqa: F401
+    _CARD_LINE_RE,
     DecklistRepository,
+    DecklistSummary,
     PlaintextRepository,
+    _format_save_file,
+    _get_save_path,
+    _parse_save_file,
 )
 from deckslots.templates import (
     Template,
@@ -44,11 +51,9 @@ class DispatchedHandler(Protocol):
 class Session:
     decklist: Decklist | None = None
     scryfall_index: dict | None = None
-    repository: DecklistRepository = field(default_factory=PlaintextRepository)
-
-
-_CARD_LINE_RE = re.compile(r"^(\d+)\s+(.+)$")
-_SAVE_CAT_RE = re.compile(r"^(.+) \[(\d+) slots\]$")
+    repository: DecklistRepository = dataclasses.field(
+        default_factory=PlaintextRepository
+    )
 
 
 @dataclass
@@ -439,16 +444,20 @@ def handle_decklist_export(session: Session, cmd: ParsedCommand) -> str:
 
 
 def handle_decklist_load(session: Session, cmd: ParsedCommand) -> str:
+    summaries = session.repository.list()
+    if not summaries:
+        logger.warning("Repository is empty: no decks to load.")
+        return "No saved decklist found."
     try:
-        deck = session.repository.load()
-    except (DecklistError, OSError) as e:
+        deck = session.repository.load(summaries[0].id)
+    except (DecklistError, OSError, KeyError) as e:
         logger.warning("Handler error: %s", e)
         return f"Error loading save file: {e}"
     if deck is None:
         logger.warning("Save file not found")
         return "No saved decklist found."
     session.decklist = deck
-    logger.debug("Deck loaded: %s", deck.name)
+    logger.debug("Deck loaded via %s", type(session.repository).__name__)
     return f"Loaded '{deck.name}'."
 
 
@@ -456,7 +465,7 @@ def handle_decklist_save(session: Session, cmd: ParsedCommand) -> str:
     if session.decklist is None:
         return NO_ACTIVE_DECK
     session.repository.save(session.decklist)
-    logger.debug("Deck saved: %s", session.decklist.name)
+    logger.debug("Deck saved via %s", type(session.repository).__name__)
     return f"Saved '{session.decklist.name}'."
 
 

--- a/src/deckslots/cli/commands.py
+++ b/src/deckslots/cli/commands.py
@@ -469,6 +469,50 @@ def handle_decklist_save(session: Session, cmd: ParsedCommand) -> str:
     return f"Saved '{session.decklist.name}'."
 
 
+def handle_decklist_list(session: Session, cmd: ParsedCommand) -> str:
+    summaries = session.repository.list()
+    if not summaries:
+        return "No decks saved."
+    lines = ["Saved decks:"]
+    for s in summaries:
+        # updated_at is ISO 8601; show the date portion for readability.
+        date = s.updated_at[:10] if s.updated_at else "?"
+        lines.append(f"  {s.id}. {s.name} — {s.total_filled} cards ({date})")
+    return "\n".join(lines)
+
+
+def handle_decklist_switch(session: Session, cmd: ParsedCommand) -> str:
+    if not cmd.args:
+        return "Usage: decklist switch <name>"
+    name = " ".join(cmd.args)
+    deck = session.repository.load_by_name(name)
+    if deck is None:
+        return f"Deck '{name}' not found."
+    session.decklist = deck
+    return f"Switched to '{name}'."
+
+
+def handle_decklist_delete(session: Session, cmd: ParsedCommand) -> str:
+    import click
+
+    if not cmd.args:
+        return "Usage: decklist delete <name>"
+    name = " ".join(cmd.args)
+    target = None
+    for s in session.repository.list():
+        if s.name == name:
+            target = s
+            break
+    if target is None:
+        return f"Deck '{name}' not found."
+    if not click.confirm(f"Delete '{name}'? This cannot be undone.", default=False):
+        return "Aborted."
+    session.repository.delete(target.id)
+    if session.decklist is not None and session.decklist.name == name:
+        session.decklist = None
+    return f"Deleted '{name}'."
+
+
 def validate_decklist_rename(session: Session) -> str | None:
     """Returns an error string if rename is not possible, else None."""
     if session.decklist is None:
@@ -595,6 +639,9 @@ def handle_help() -> str:
             "  decklist export <file>        Export the active decklist to a text file",
             "  decklist save                 Save the active decklist",
             "  decklist load                 Load the last saved decklist",
+            "  decklist list                 List all saved decks",
+            "  decklist switch <name>        Switch the active deck to a saved one",
+            "  decklist delete <name>        Remove a saved deck (prompts to confirm)",
             "  decklist rename               Rename the active decklist",
             "  decklist apply-template <n>   Apply a template to the active decklist",
             "  decklist enable-partners      Allow two commanders (partner mechanic)",
@@ -645,6 +692,9 @@ def register_all_handlers(
         ("decklist", "export"): lambda cmd: handle_decklist_export(session, cmd),
         ("decklist", "save"): lambda cmd: handle_decklist_save(session, cmd),
         ("decklist", "load"): lambda cmd: handle_decklist_load(session, cmd),
+        ("decklist", "list"): lambda cmd: handle_decklist_list(session, cmd),
+        ("decklist", "switch"): lambda cmd: handle_decklist_switch(session, cmd),
+        ("decklist", "delete"): lambda cmd: handle_decklist_delete(session, cmd),
         ("decklist", "enable-partners"): lambda cmd: handle_decklist_enable_partners(
             session, cmd
         ),

--- a/src/deckslots/cli/repl.py
+++ b/src/deckslots/cli/repl.py
@@ -82,33 +82,33 @@ def run_repl() -> None:
     session = Session()
     registry = register_all_handlers(session)
 
-    try:
-        deck = session.repository.load()
-    except (OSError, ValueError) as e:
-        deck = None
-        _logger.warning("Save file load failed, entering recovery: %s", e)
-        click.echo(f"Warning: could not load save file: {e}.")
-        click.echo("Options:")
-        click.echo("  discard — delete the save file and start fresh")
-        click.echo("  exit    — quit so you can inspect the file manually")
-        while True:
-            click.echo("deckslots(recovery)> ", nl=False)
-            try:
-                choice = input().strip().lower()
-            except (EOFError, KeyboardInterrupt):
-                click.echo("Goodbye.")
-                return
-            if choice == "discard":
-                session.repository.delete()
-                click.echo("Save file deleted. Starting fresh.")
-                break
-            elif choice == "exit":
-                click.echo("Goodbye.")
-                return
-    if deck is not None:
-        session.decklist = deck
-        click.echo(f"Resumed '{session.decklist.name}'.")
-        click.echo(render_status_line(session, is_validation_enabled()))
+    summaries = session.repository.list()
+    if summaries:
+        latest = summaries[0]
+        try:
+            session.decklist = session.repository.load(latest.id)
+            click.echo(f"Resumed '{session.decklist.name}'.")
+            click.echo(render_status_line(session, is_validation_enabled()))
+        except (OSError, ValueError, KeyError) as e:
+            _logger.warning("Save file load failed, entering recovery: %s", e)
+            click.echo(f"Warning: could not load save file: {e}.")
+            click.echo("Options:")
+            click.echo("  discard — delete the save file and start fresh")
+            click.echo("  exit    — quit so you can inspect the file manually")
+            while True:
+                click.echo("deckslots(recovery)> ", nl=False)
+                try:
+                    choice = input().strip().lower()
+                except (EOFError, KeyboardInterrupt):
+                    click.echo("Goodbye.")
+                    return
+                if choice == "discard":
+                    session.repository.delete(latest.id)
+                    click.echo("Save file deleted. Starting fresh.")
+                    break
+                elif choice == "exit":
+                    click.echo("Goodbye.")
+                    return
 
     _load_scryfall_index(session)
 

--- a/src/deckslots/cli/repl.py
+++ b/src/deckslots/cli/repl.py
@@ -16,8 +16,9 @@ from deckslots.cli.commands import (
 )
 from deckslots.cli.parser import parse_command
 from deckslots.cli.status import render_status_line
-from deckslots.config import is_validation_enabled
+from deckslots.config import get_storage_backend, is_validation_enabled
 from deckslots.logging_config import setup_logging
+from deckslots.storage import PlaintextRepository, SqliteRepository
 from deckslots.templates import user_template_exists
 
 _logger = logging.getLogger("deckslots.cli.repl")
@@ -76,10 +77,17 @@ def _load_scryfall_index(session: Session) -> None:
         click.echo(f"Download failed: {exc}")
 
 
+def _build_repository():
+    backend = get_storage_backend()
+    if backend == "sqlite":
+        return SqliteRepository()
+    return PlaintextRepository()
+
+
 def run_repl() -> None:
     """Start the deckslots interactive REPL."""
     setup_logging()
-    session = Session()
+    session = Session(repository=_build_repository())
     registry = register_all_handlers(session)
 
     summaries = session.repository.list()

--- a/src/deckslots/config.py
+++ b/src/deckslots/config.py
@@ -27,3 +27,20 @@ def is_validation_enabled() -> bool:
     except (json.JSONDecodeError, OSError):
         return True
     return bool(data.get("validation_enabled", True))
+
+
+def get_storage_backend() -> str:
+    """Return the configured storage backend ('plaintext' or 'sqlite').
+
+    Defaults to 'plaintext' when the config file is absent or malformed.
+    Unknown values fall back to 'plaintext' too.
+    """
+    path = get_config_path()
+    if not path.exists():
+        return "plaintext"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return "plaintext"
+    value = str(data.get("storage_backend", "plaintext"))
+    return value if value in ("plaintext", "sqlite") else "plaintext"

--- a/src/deckslots/logging_config.py
+++ b/src/deckslots/logging_config.py
@@ -17,9 +17,7 @@ def setup_logging(level: str | None = None) -> None:
     logger.addHandler(sh)
     log_dir = Path.home() / ".local" / "share" / "deckslots"
     log_dir.mkdir(parents=True, exist_ok=True)
-    fh = RotatingFileHandler(
-        log_dir / "debug.log", maxBytes=1_000_000, backupCount=3
-    )
+    fh = RotatingFileHandler(log_dir / "debug.log", maxBytes=1_000_000, backupCount=3)
     fh.setLevel(logging.DEBUG)
     fh.setFormatter(
         logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")

--- a/src/deckslots/models.py
+++ b/src/deckslots/models.py
@@ -138,9 +138,7 @@ class Decklist:
                 if isinstance(other, CappedCategory) and card in other.cards:
                     raise CardError(f"'{card}' is already in the decklist.")
         if cat.is_full:
-            raise SlotError(
-                f"Category '{category_name}' is full (no available slots)."
-            )
+            raise SlotError(f"Category '{category_name}' is full (no available slots).")
         cat.cards.append(card)
 
     def find_card(self, card: str) -> str | None:

--- a/src/deckslots/storage.py
+++ b/src/deckslots/storage.py
@@ -11,8 +11,10 @@ not storage.
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 import re
+import sqlite3
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -193,8 +195,6 @@ class PlaintextRepository:
         except (ParseError, OSError, ValueError):
             name, total_filled = "?", 0
         mtime = self._path.stat().st_mtime
-        import datetime as _dt
-
         updated_at = _dt.datetime.fromtimestamp(mtime, tz=_dt.timezone.utc).isoformat()
         return [
             DecklistSummary(
@@ -208,3 +208,245 @@ class PlaintextRepository:
     def delete(self, deck_id: int) -> None:  # noqa: ARG002 - single-deck backend
         if self._path.exists():
             self._path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# SqliteRepository
+# ---------------------------------------------------------------------------
+
+
+_SCHEMA_V1 = """
+CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT);
+
+CREATE TABLE decks (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  partners_enabled INTEGER NOT NULL DEFAULT 0,
+  background_enabled INTEGER NOT NULL DEFAULT 0,
+  companion_enabled INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE categories (
+  id INTEGER PRIMARY KEY,
+  deck_id INTEGER NOT NULL REFERENCES decks(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('capped', 'uncapped')),
+  fixed INTEGER NOT NULL,
+  user_addable INTEGER NOT NULL,
+  total_slots INTEGER,
+  position INTEGER NOT NULL,
+  UNIQUE (deck_id, name)
+);
+
+CREATE TABLE allowed_cards (
+  category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  card_name TEXT NOT NULL,
+  PRIMARY KEY (category_id, card_name)
+);
+
+CREATE TABLE cards (
+  id INTEGER PRIMARY KEY,
+  category_id INTEGER NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  position INTEGER NOT NULL
+);
+CREATE INDEX cards_by_category ON cards (category_id, position);
+"""
+
+
+def _get_db_path() -> Path:
+    data_home = os.environ.get("XDG_DATA_HOME", "")
+    base = Path(data_home) if data_home else Path.home() / ".local" / "share"
+    return base / "deckslots" / "library.db"
+
+
+def _migrate(conn: sqlite3.Connection) -> None:
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'"
+    )
+    has_schema = cur.fetchone() is not None
+    if not has_schema:
+        conn.executescript(_SCHEMA_V1)
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (1, ?)",
+            (_dt.datetime.now(tz=_dt.timezone.utc).isoformat(),),
+        )
+        conn.commit()
+
+
+class SqliteRepository:
+    """Multi-deck backend backed by SQLite.
+
+    Implements :class:`DecklistRepository`. The default database path is
+    ``$XDG_DATA_HOME/deckslots/library.db``. Schema migrations run on every
+    open via :func:`_migrate` and are idempotent.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path if path is not None else _get_db_path()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            _migrate(conn)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path))
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def save(self, deck: Decklist) -> int:
+        now = _dt.datetime.now(tz=_dt.timezone.utc).isoformat()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id FROM decks WHERE name = ?", (deck.name,)
+            ).fetchone()
+            if row is not None:
+                deck_id = row[0]
+                conn.execute(
+                    "UPDATE decks SET partners_enabled=?, background_enabled=?, "
+                    "companion_enabled=?, updated_at=? WHERE id=?",
+                    (
+                        int(deck.partners_enabled),
+                        int(deck.background_enabled),
+                        int(deck.companion_enabled),
+                        now,
+                        deck_id,
+                    ),
+                )
+                conn.execute("DELETE FROM categories WHERE deck_id=?", (deck_id,))
+            else:
+                cur = conn.execute(
+                    "INSERT INTO decks (name, partners_enabled, background_enabled, "
+                    "companion_enabled, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        deck.name,
+                        int(deck.partners_enabled),
+                        int(deck.background_enabled),
+                        int(deck.companion_enabled),
+                        now,
+                        now,
+                    ),
+                )
+                deck_id = cur.lastrowid
+            for pos, cat in enumerate(deck.categories.values()):
+                kind = "capped" if isinstance(cat, CappedCategory) else "uncapped"
+                total_slots = (
+                    cat.total_slots if isinstance(cat, CappedCategory) else None
+                )
+                cur = conn.execute(
+                    "INSERT INTO categories (deck_id, name, kind, fixed, "
+                    "user_addable, total_slots, position) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        deck_id,
+                        cat.name,
+                        kind,
+                        int(cat.fixed),
+                        int(cat.user_addable),
+                        total_slots,
+                        pos,
+                    ),
+                )
+                cat_id = cur.lastrowid
+                if cat.allowed_cards:
+                    conn.executemany(
+                        "INSERT INTO allowed_cards (category_id, card_name) "
+                        "VALUES (?, ?)",
+                        [(cat_id, c) for c in cat.allowed_cards],
+                    )
+                for cpos, card in enumerate(cat.cards):
+                    conn.execute(
+                        "INSERT INTO cards (category_id, name, position) "
+                        "VALUES (?, ?, ?)",
+                        (cat_id, card, cpos),
+                    )
+            conn.commit()
+            return int(deck_id)
+
+    def load(self, deck_id: int) -> Decklist:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT name, partners_enabled, background_enabled, "
+                "companion_enabled FROM decks WHERE id=?",
+                (deck_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(deck_id)
+            name, partners, background, companion = row
+            categories: dict[str, CappedCategory | UncappedCategory] = {}
+            cat_rows = conn.execute(
+                "SELECT id, name, kind, fixed, user_addable, total_slots "
+                "FROM categories WHERE deck_id=? ORDER BY position",
+                (deck_id,),
+            ).fetchall()
+            for cat_id, cname, kind, fixed, user_addable, total_slots in cat_rows:
+                allowed_rows = conn.execute(
+                    "SELECT card_name FROM allowed_cards WHERE category_id=?",
+                    (cat_id,),
+                ).fetchall()
+                allowed = (
+                    frozenset(r[0] for r in allowed_rows) if allowed_rows else None
+                )
+                card_rows = conn.execute(
+                    "SELECT name FROM cards WHERE category_id=? ORDER BY position",
+                    (cat_id,),
+                ).fetchall()
+                cards = [r[0] for r in card_rows]
+                if kind == "capped":
+                    cat: CappedCategory | UncappedCategory = CappedCategory(
+                        name=cname,
+                        total_slots=int(total_slots),
+                        fixed=bool(fixed),
+                        allowed_cards=allowed,
+                        user_addable=bool(user_addable),
+                        cards=cards,
+                    )
+                else:
+                    cat = UncappedCategory(
+                        name=cname,
+                        fixed=bool(fixed),
+                        allowed_cards=allowed,
+                        user_addable=bool(user_addable),
+                        cards=cards,
+                    )
+                categories[cname.lower()] = cat
+        return Decklist(
+            name=name,
+            categories=categories,
+            partners_enabled=bool(partners),
+            background_enabled=bool(background),
+            companion_enabled=bool(companion),
+        )
+
+    def load_by_name(self, name: str) -> Decklist | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id FROM decks WHERE name = ?", (name,)
+            ).fetchone()
+        if row is None:
+            return None
+        return self.load(int(row[0]))
+
+    def list(self) -> list[DecklistSummary]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT d.id, d.name, d.updated_at, COUNT(c.id) AS total_filled "
+                "FROM decks d "
+                "LEFT JOIN categories cat ON cat.deck_id = d.id "
+                "LEFT JOIN cards c ON c.category_id = cat.id "
+                "GROUP BY d.id, d.name, d.updated_at "
+                "ORDER BY d.updated_at DESC, d.id DESC"
+            ).fetchall()
+        return [
+            DecklistSummary(
+                id=int(r[0]), name=r[1], total_filled=int(r[3]), updated_at=r[2]
+            )
+            for r in rows
+        ]
+
+    def delete(self, deck_id: int) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM decks WHERE id = ?", (deck_id,))
+            conn.commit()

--- a/src/deckslots/storage.py
+++ b/src/deckslots/storage.py
@@ -289,6 +289,25 @@ class SqliteRepository:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         with self._connect() as conn:
             _migrate(conn)
+        self._maybe_import_legacy()
+
+    def _maybe_import_legacy(self) -> None:
+        """Seed an empty db from a legacy plaintext save, if present.
+
+        First-run convenience for users opting into the SQLite backend who
+        already have a deck on disk. The plaintext file is left in place
+        as a read-only fallback.
+        """
+        if self.list():
+            return
+        legacy = _get_save_path()
+        if not legacy.exists():
+            return
+        try:
+            deck = _parse_save_file(str(legacy))
+        except (ParseError, OSError, ValueError):
+            return
+        self.save(deck)
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self._path))

--- a/src/deckslots/storage.py
+++ b/src/deckslots/storage.py
@@ -1,8 +1,20 @@
+"""Persistence layer for Decklists.
+
+This module owns the storage seam (`DecklistRepository`) that the REPL,
+the GUI, and future SQLite backend share. The plaintext format helpers
+(`_format_save_file`, `_parse_save_file`) live here because they are
+the on-disk format of the default `PlaintextRepository` backend; the
+interop helpers `_format_export_file` / `_parse_import_file` stay in
+`commands.py` because they are user-facing Moxfield/Archidekt encoders,
+not storage.
+"""
+
 from __future__ import annotations
 
 import os
 import re
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
@@ -15,6 +27,9 @@ from deckslots.models import (
 
 _CARD_LINE_RE = re.compile(r"^(\d+)\s+(.+)$")
 _SAVE_CAT_RE = re.compile(r"^(.+) \[(\d+) slots\]$")
+
+# Single-deck backends (PlaintextRepository) always use this synthetic id.
+_PLAINTEXT_DECK_ID = 1
 
 
 def _get_save_path() -> Path:
@@ -65,8 +80,6 @@ def _parse_save_file(path: str) -> Decklist:
         raise ParseError("Save file missing '# <name>' header line.")
 
     deck = Decklist.create(name)
-    # Temporarily expand Commander to accept any number of cards during load;
-    # the correct slot count is set after all cards are read.
     commander_cat = deck.categories["commander"]
     assert isinstance(commander_cat, CappedCategory)
     commander_cat.total_slots = 99
@@ -109,7 +122,6 @@ def _parse_save_file(path: str) -> Decklist:
             for _ in range(qty):
                 deck.add_card(card, current_category)
 
-    # Set Commander slot count from the number of loaded cards
     loaded_commander_cat = deck.categories.get("commander")
     if loaded_commander_cat is not None and isinstance(
         loaded_commander_cat, CappedCategory
@@ -119,25 +131,80 @@ def _parse_save_file(path: str) -> Decklist:
     return deck
 
 
+@dataclass(frozen=True)
+class DecklistSummary:
+    """Lightweight row returned by ``DecklistRepository.list``."""
+
+    id: int
+    name: str
+    total_filled: int
+    updated_at: str
+
+
 class DecklistRepository(Protocol):
-    def save(self, deck: Decklist) -> None: ...
-    def load(self) -> Decklist | None: ...
-    def delete(self) -> None: ...
+    """Storage seam shared by the plaintext and SQLite backends."""
+
+    def save(self, deck: Decklist) -> int: ...
+
+    def load(self, deck_id: int) -> Decklist: ...
+
+    def load_by_name(self, name: str) -> Decklist | None: ...
+
+    def list(self) -> list[DecklistSummary]: ...
+
+    def delete(self, deck_id: int) -> None: ...
 
 
 class PlaintextRepository:
+    """Single-file backend writing to ``$XDG_STATE_HOME/deckslots/decklist.bak``.
+
+    Implements :class:`DecklistRepository`. Because there is only ever one
+    deck on disk, ``save`` always returns ``1`` and ``load`` ignores the
+    ``deck_id`` argument (raising ``KeyError`` if the file is absent).
+    """
+
     def __init__(self, path: Path | None = None) -> None:
         self._path = path if path is not None else _get_save_path()
 
-    def save(self, deck: Decklist) -> None:
+    def save(self, deck: Decklist) -> int:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._path.write_text(_format_save_file(deck))
+        return _PLAINTEXT_DECK_ID
 
-    def load(self) -> Decklist | None:
+    def load(self, deck_id: int) -> Decklist:
         if not self._path.exists():
-            return None
+            raise KeyError(deck_id)
         return _parse_save_file(str(self._path))
 
-    def delete(self) -> None:
+    def load_by_name(self, name: str) -> Decklist | None:
+        if not self._path.exists():
+            return None
+        deck = _parse_save_file(str(self._path))
+        return deck if deck.name == name else None
+
+    def list(self) -> list[DecklistSummary]:
+        if not self._path.exists():
+            return []
+        # Surface parse failures via load(); list() must succeed so the REPL
+        # can detect a present-but-corrupt save and offer recovery.
+        try:
+            deck = _parse_save_file(str(self._path))
+            name, total_filled = deck.name, deck.total_filled
+        except (ParseError, OSError, ValueError):
+            name, total_filled = "?", 0
+        mtime = self._path.stat().st_mtime
+        import datetime as _dt
+
+        updated_at = _dt.datetime.fromtimestamp(mtime, tz=_dt.timezone.utc).isoformat()
+        return [
+            DecklistSummary(
+                id=_PLAINTEXT_DECK_ID,
+                name=name,
+                total_filled=total_filled,
+                updated_at=updated_at,
+            )
+        ]
+
+    def delete(self, deck_id: int) -> None:  # noqa: ARG002 - single-deck backend
         if self._path.exists():
             self._path.unlink()

--- a/tests/functional/01-startup.md
+++ b/tests/functional/01-startup.md
@@ -64,6 +64,9 @@ deckslots> Available commands:
   decklist export <file>        Export the active decklist to a text file
   decklist save                 Save the active decklist
   decklist load                 Load the last saved decklist
+  decklist list                 List all saved decks
+  decklist switch <name>        Switch the active deck to a saved one
+  decklist delete <name>        Remove a saved deck (prompts to confirm)
   decklist rename               Rename the active decklist
   decklist apply-template <n>   Apply a template to the active decklist
   decklist enable-partners      Allow two commanders (partner mechanic)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2997,7 +2997,7 @@ class TestSessionHasScryfallIndex:
 class TestDecklistListHandler:
     def test_empty_library_message(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        from deckslots.commands import handle_decklist_list
+        from deckslots.cli.commands import handle_decklist_list
 
         session = Session()
         result = handle_decklist_list(
@@ -3007,7 +3007,7 @@ class TestDecklistListHandler:
 
     def test_list_shows_saved_deck(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        from deckslots.commands import handle_decklist_list
+        from deckslots.cli.commands import handle_decklist_list
 
         session = Session()
         session.decklist = Decklist.create("Atraxa Stax")
@@ -3020,7 +3020,7 @@ class TestDecklistListHandler:
 
     def test_list_works_without_active_decklist(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        from deckslots.commands import handle_decklist_list
+        from deckslots.cli.commands import handle_decklist_list
 
         session = Session()
         result = handle_decklist_list(
@@ -3031,7 +3031,7 @@ class TestDecklistListHandler:
 
 class TestDecklistSwitchHandler:
     def test_switch_without_name_shows_usage(self):
-        from deckslots.commands import handle_decklist_switch
+        from deckslots.cli.commands import handle_decklist_switch
 
         session = Session()
         result = handle_decklist_switch(
@@ -3041,7 +3041,7 @@ class TestDecklistSwitchHandler:
 
     def test_switch_unknown_name_returns_error(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        from deckslots.commands import handle_decklist_switch
+        from deckslots.cli.commands import handle_decklist_switch
 
         session = Session()
         result = handle_decklist_switch(
@@ -3052,7 +3052,7 @@ class TestDecklistSwitchHandler:
 
     def test_switch_loads_named_deck(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        from deckslots.commands import handle_decklist_switch
+        from deckslots.cli.commands import handle_decklist_switch
         from deckslots.storage import SqliteRepository
 
         session = Session(repository=SqliteRepository())
@@ -3075,7 +3075,7 @@ class TestDecklistSwitchHandler:
 
 class TestDecklistDeleteHandler:
     def test_delete_without_name_shows_usage(self):
-        from deckslots.commands import handle_decklist_delete
+        from deckslots.cli.commands import handle_decklist_delete
 
         session = Session()
         result = handle_decklist_delete(
@@ -3085,7 +3085,7 @@ class TestDecklistDeleteHandler:
 
     def test_delete_unknown_name_returns_error(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        from deckslots.commands import handle_decklist_delete
+        from deckslots.cli.commands import handle_decklist_delete
 
         session = Session()
         result = handle_decklist_delete(
@@ -3100,7 +3100,7 @@ class TestDecklistDeleteHandler:
         import click as _click
 
         monkeypatch.setattr(_click, "confirm", lambda *a, **kw: True)
-        from deckslots.commands import handle_decklist_delete
+        from deckslots.cli.commands import handle_decklist_delete
         from deckslots.storage import SqliteRepository
 
         session = Session(repository=SqliteRepository())
@@ -3121,7 +3121,7 @@ class TestDecklistDeleteHandler:
         import click as _click
 
         monkeypatch.setattr(_click, "confirm", lambda *a, **kw: False)
-        from deckslots.commands import handle_decklist_delete
+        from deckslots.cli.commands import handle_decklist_delete
         from deckslots.storage import SqliteRepository
 
         session = Session(repository=SqliteRepository())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2987,3 +2987,159 @@ class TestSessionHasScryfallIndex:
     def test_session_starts_with_no_index(self):
         session = Session()
         assert session.scryfall_index is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.6 / 1.7 / 1.8 — multi-deck CLI handlers
+# ---------------------------------------------------------------------------
+
+
+class TestDecklistListHandler:
+    def test_empty_library_message(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        from deckslots.commands import handle_decklist_list
+
+        session = Session()
+        result = handle_decklist_list(session, _make_cmd("decklist list", "decklist", "list", []))
+        assert "No decks saved" in result
+
+    def test_list_shows_saved_deck(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        from deckslots.commands import handle_decklist_list
+
+        session = Session()
+        session.decklist = Decklist.create("Atraxa Stax")
+        session.decklist.add_card("Atraxa, Praetors' Voice", "Commander")
+        session.repository.save(session.decklist)
+        result = handle_decklist_list(
+            session, _make_cmd("decklist list", "decklist", "list", [])
+        )
+        assert "Atraxa Stax" in result
+
+    def test_list_works_without_active_decklist(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        from deckslots.commands import handle_decklist_list
+
+        session = Session()
+        result = handle_decklist_list(
+            session, _make_cmd("decklist list", "decklist", "list", [])
+        )
+        assert result  # should not raise; should return a string
+
+
+class TestDecklistSwitchHandler:
+    def test_switch_without_name_shows_usage(self):
+        from deckslots.commands import handle_decklist_switch
+
+        session = Session()
+        result = handle_decklist_switch(
+            session, _make_cmd("decklist switch", "decklist", "switch", [])
+        )
+        assert "Usage" in result
+
+    def test_switch_unknown_name_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        from deckslots.commands import handle_decklist_switch
+
+        session = Session()
+        result = handle_decklist_switch(
+            session,
+            _make_cmd("decklist switch Nope", "decklist", "switch", ["Nope"]),
+        )
+        assert "not found" in result.lower()
+
+    def test_switch_loads_named_deck(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        from deckslots.commands import handle_decklist_switch
+        from deckslots.storage import SqliteRepository
+
+        session = Session(repository=SqliteRepository())
+        d1 = Decklist.create("Deck One")
+        d1.add_card("Atraxa, Praetors' Voice", "Commander")
+        d2 = Decklist.create("Deck Two")
+        d2.add_card("Animar, Soul of Elements", "Commander")
+        session.repository.save(d1)
+        session.repository.save(d2)
+        session.decklist = d1
+        result = handle_decklist_switch(
+            session,
+            _make_cmd("decklist switch Deck Two", "decklist", "switch", ["Deck", "Two"]),
+        )
+        assert "Deck Two" in result
+        assert session.decklist.name == "Deck Two"
+
+
+class TestDecklistDeleteHandler:
+    def test_delete_without_name_shows_usage(self):
+        from deckslots.commands import handle_decklist_delete
+
+        session = Session()
+        result = handle_decklist_delete(
+            session, _make_cmd("decklist delete", "decklist", "delete", [])
+        )
+        assert "Usage" in result
+
+    def test_delete_unknown_name_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        from deckslots.commands import handle_decklist_delete
+
+        session = Session()
+        result = handle_decklist_delete(
+            session,
+            _make_cmd("decklist delete X", "decklist", "delete", ["X"]),
+        )
+        assert "not found" in result.lower()
+
+    def test_delete_removes_from_library_and_clears_active(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        # Auto-confirm the click.confirm prompt.
+        import click as _click
+        monkeypatch.setattr(_click, "confirm", lambda *a, **kw: True)
+        from deckslots.commands import handle_decklist_delete
+        from deckslots.storage import SqliteRepository
+
+        session = Session(repository=SqliteRepository())
+        d1 = Decklist.create("Doomed")
+        d1.add_card("Atraxa, Praetors' Voice", "Commander")
+        session.repository.save(d1)
+        session.decklist = d1
+        result = handle_decklist_delete(
+            session,
+            _make_cmd("decklist delete Doomed", "decklist", "delete", ["Doomed"]),
+        )
+        assert "Deleted" in result
+        assert session.repository.list() == []
+        assert session.decklist is None
+
+    def test_delete_aborts_when_user_declines(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        import click as _click
+        monkeypatch.setattr(_click, "confirm", lambda *a, **kw: False)
+        from deckslots.commands import handle_decklist_delete
+        from deckslots.storage import SqliteRepository
+
+        session = Session(repository=SqliteRepository())
+        d = Decklist.create("Keepme")
+        d.add_card("Atraxa, Praetors' Voice", "Commander")
+        session.repository.save(d)
+        result = handle_decklist_delete(
+            session,
+            _make_cmd("decklist delete Keepme", "decklist", "delete", ["Keepme"]),
+        )
+        assert "Aborted" in result
+        assert len(session.repository.list()) == 1
+
+
+class TestMultiDeckCommandsRegistered:
+    def test_dispatch_routes_decklist_list(self):
+        session = Session()
+        registry = register_all_handlers(session)
+        assert ("decklist", "list") in registry
+        assert ("decklist", "switch") in registry
+        assert ("decklist", "delete") in registry
+
+    def test_help_mentions_multi_deck_commands(self):
+        text = handle_help()
+        assert "decklist list" in text
+        assert "decklist switch" in text
+        assert "decklist delete" in text

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3000,7 +3000,9 @@ class TestDecklistListHandler:
         from deckslots.commands import handle_decklist_list
 
         session = Session()
-        result = handle_decklist_list(session, _make_cmd("decklist list", "decklist", "list", []))
+        result = handle_decklist_list(
+            session, _make_cmd("decklist list", "decklist", "list", [])
+        )
         assert "No decks saved" in result
 
     def test_list_shows_saved_deck(self, tmp_path, monkeypatch):
@@ -3063,7 +3065,9 @@ class TestDecklistSwitchHandler:
         session.decklist = d1
         result = handle_decklist_switch(
             session,
-            _make_cmd("decklist switch Deck Two", "decklist", "switch", ["Deck", "Two"]),
+            _make_cmd(
+                "decklist switch Deck Two", "decklist", "switch", ["Deck", "Two"]
+            ),
         )
         assert "Deck Two" in result
         assert session.decklist.name == "Deck Two"
@@ -3094,6 +3098,7 @@ class TestDecklistDeleteHandler:
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
         # Auto-confirm the click.confirm prompt.
         import click as _click
+
         monkeypatch.setattr(_click, "confirm", lambda *a, **kw: True)
         from deckslots.commands import handle_decklist_delete
         from deckslots.storage import SqliteRepository
@@ -3114,6 +3119,7 @@ class TestDecklistDeleteHandler:
     def test_delete_aborts_when_user_declines(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
         import click as _click
+
         monkeypatch.setattr(_click, "confirm", lambda *a, **kw: False)
         from deckslots.commands import handle_decklist_delete
         from deckslots.storage import SqliteRepository

--- a/tests/test_repl_functional.py
+++ b/tests/test_repl_functional.py
@@ -386,9 +386,7 @@ class TestUncategorized:
     def test_warning_appears_on_every_response_while_uncategorized_has_cards(
         self, tmp_path
     ):
-        out = _run(
-            f"decklist import {DECK_TXT}\ncategory list\nquit\n", tmp_path
-        )
+        out = _run(f"decklist import {DECK_TXT}\ncategory list\nquit\n", tmp_path)
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Warning: 1 card(s) in Uncategorized. "
@@ -406,9 +404,7 @@ class TestUncategorized:
         )
 
     def test_no_warning_when_decklist_has_no_uncategorized_category(self, tmp_path):
-        out = _run(
-            "decklist create TestDeck\ncategory list\nquit\n", tmp_path
-        )
+        out = _run("decklist create TestDeck\ncategory list\nquit\n", tmp_path)
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
@@ -694,9 +690,7 @@ class TestRename:
         )
 
     def test_category_rename_without_args_shows_usage(self, tmp_path):
-        out = _run(
-            "decklist create TestDeck\ncategory rename\nquit\n", tmp_path
-        )
+        out = _run("decklist create TestDeck\ncategory rename\nquit\n", tmp_path)
         assert out == (
             "deckslots> Welcome to deckslots.\n"
             "deckslots> Created decklist 'TestDeck'.\n"
@@ -868,9 +862,7 @@ class TestBackground:
             "deckslots> Goodbye.\n"
         )
 
-    def test_overcrowded_warning_fires_after_loading_save_with_no_mode(
-        self, tmp_path
-    ):
+    def test_overcrowded_warning_fires_after_loading_save_with_no_mode(self, tmp_path):
         state_home = tmp_path / "state"
         _run(
             "decklist create BgDeck\ndecklist enable-background\n"
@@ -969,9 +961,7 @@ class TestCompanion:
             f"decklist export {export_path}\nquit\n",
             state1,
         )
-        out2 = _run(
-            f"decklist import {export_path}\ndecklist show\nquit\n", state2
-        )
+        out2 = _run(f"decklist import {export_path}\ndecklist show\nquit\n", state2)
         assert "Companion: 1/1 slots filled" in out2
 
 
@@ -998,7 +988,10 @@ class TestTemplates:
             tmp_path,
             data_home=tmp_path / "data",
         )
-        assert "Created decklist 'Aristocrats' with template 'Goldfish Fundamentals'." in out  # noqa: E501
+        assert (
+            "Created decklist 'Aristocrats' with template 'Goldfish Fundamentals'."
+            in out
+        )  # noqa: E501
         assert "Ramp: 0/10 slots filled" in out
         assert "Card Advantage: 0/10 slots filled" in out
 
@@ -1011,9 +1004,7 @@ class TestTemplates:
         assert "Template 'NoSuchTemplate' not found." in out
         assert "No active decklist." in out
 
-    def test_decklist_apply_template_applies_categories_and_moves_cards(
-        self, tmp_path
-    ):
+    def test_decklist_apply_template_applies_categories_and_moves_cards(self, tmp_path):
         out = _run(
             "decklist create TestDeck\ncategory create Old 5\ncard add Old Sol Ring\n"
             "decklist apply-template Goldfish Fundamentals\nquit\n",
@@ -1098,9 +1089,9 @@ class TestTemplates:
         data_home = tmp_path / "data"
         out = _run(
             "decklist create TestDeck\ncategory create Ramp 10\n"
-            "template save MyTemplate\n"   # first save — no prompt
-            "template save MyTemplate\n"   # second save — overwrite prompt fires
-            "yes\n"                        # full word; current code rejects this
+            "template save MyTemplate\n"  # first save — no prompt
+            "template save MyTemplate\n"  # second save — overwrite prompt fires
+            "yes\n"  # full word; current code rejects this
             "quit\n",
             tmp_path,
             data_home=data_home,
@@ -1171,7 +1162,9 @@ class TestValidation:
             tmp_path,
             cache_home=cache_home,
         )
-        assert "Warning: 'Oko, Thief of Crowns' is not legal in Commander format." in out  # noqa: E501
+        assert (
+            "Warning: 'Oko, Thief of Crowns' is not legal in Commander format." in out
+        )  # noqa: E501
         assert "Added 'Oko, Thief of Crowns' to 'PW'." in out
 
     def test_basic_lands_skip_validation(self, tmp_path):

--- a/tests/test_repl_functional.py
+++ b/tests/test_repl_functional.py
@@ -38,6 +38,7 @@ def _run(
     state_home: Path,
     data_home: Path | None = None,
     cache_home: Path | None = None,
+    config_home: Path | None = None,
 ) -> str:
     """Invoke the deckslots REPL in-process and return captured stdout."""
     env: dict[str, str] = {"XDG_STATE_HOME": str(state_home)}
@@ -45,6 +46,8 @@ def _run(
         env["XDG_DATA_HOME"] = str(data_home)
     if cache_home is not None:
         env["XDG_CACHE_HOME"] = str(cache_home)
+    if config_home is not None:
+        env["XDG_CONFIG_HOME"] = str(config_home)
     runner = CliRunner(env=env)
     result = runner.invoke(main, input=commands)
     return result.output
@@ -1206,3 +1209,63 @@ class TestValidation:
             "Test (1/11)\n"
             "deckslots> Goodbye.\n"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.5 — storage_backend config opt-in
+# ---------------------------------------------------------------------------
+
+
+class TestStorageBackendSelection:
+    """REPL selects PlaintextRepository or SqliteRepository from config.json."""
+
+    def _write_config(self, config_home: Path, backend: str) -> None:
+        d = config_home / "deckslots"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps({"storage_backend": backend}))
+
+    def test_default_backend_writes_decklist_bak(self, tmp_path):
+        state = tmp_path / "state"
+        data = tmp_path / "data"
+        out = _run(
+            "decklist create Test\ndecklist save\nquit\n",
+            state_home=state,
+            data_home=data,
+        )
+        assert "Saved 'Test'." in out
+        assert (state / "deckslots" / "decklist.bak").exists()
+        assert not (data / "deckslots" / "library.db").exists()
+
+    def test_sqlite_backend_writes_library_db(self, tmp_path):
+        state = tmp_path / "state"
+        data = tmp_path / "data"
+        config = tmp_path / "config"
+        self._write_config(config, "sqlite")
+        out = _run(
+            "decklist create Test\ndecklist save\nquit\n",
+            state_home=state,
+            data_home=data,
+            config_home=config,
+        )
+        assert "Saved 'Test'." in out
+        assert (data / "deckslots" / "library.db").exists()
+        assert not (state / "deckslots" / "decklist.bak").exists()
+
+    def test_sqlite_backend_resumes_saved_deck_across_runs(self, tmp_path):
+        state = tmp_path / "state"
+        data = tmp_path / "data"
+        config = tmp_path / "config"
+        self._write_config(config, "sqlite")
+        _run(
+            "decklist create Resumed\ndecklist save\nquit\n",
+            state_home=state,
+            data_home=data,
+            config_home=config,
+        )
+        out2 = _run(
+            "quit\n",
+            state_home=state,
+            data_home=data,
+            config_home=config,
+        )
+        assert "Resumed 'Resumed'." in out2

--- a/tests/test_scryfall.py
+++ b/tests/test_scryfall.py
@@ -274,3 +274,31 @@ class TestConfig:
 
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         assert get_config_path() == tmp_path / "deckslots" / "config.json"
+
+    def test_storage_backend_defaults_to_plaintext(self, tmp_path, monkeypatch):
+        from deckslots.config import get_storage_backend
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        assert get_storage_backend() == "plaintext"
+
+    def test_storage_backend_reads_sqlite_from_config(self, tmp_path, monkeypatch):
+        from deckslots.config import get_storage_backend
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "deckslots"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"storage_backend": "sqlite"})
+        )
+        assert get_storage_backend() == "sqlite"
+
+    def test_storage_backend_falls_back_on_malformed_config(
+        self, tmp_path, monkeypatch
+    ):
+        from deckslots.config import get_storage_backend
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "deckslots"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text("not json")
+        assert get_storage_backend() == "plaintext"

--- a/tests/test_scryfall.py
+++ b/tests/test_scryfall.py
@@ -141,9 +141,7 @@ class TestValidateCard:
         assert result.commander_legal is True
 
     def test_dfc_full_name_found(self):
-        result = validate_card(
-            "Delver of Secrets // Insectile Aberration", self.index
-        )
+        result = validate_card("Delver of Secrets // Insectile Aberration", self.index)
         assert result.found is True
 
     def test_result_carries_original_card_name(self):

--- a/tests/test_storage_repository.py
+++ b/tests/test_storage_repository.py
@@ -1,32 +1,34 @@
-"""Tests for the DecklistRepository protocol and PlaintextRepository."""
+"""Tests for the DecklistRepository protocol and PlaintextRepository.
 
+Phase 1.1 establishes the storage seam. PlaintextRepository wraps the
+existing _format_save_file / _parse_save_file helpers and exposes them
+through the multi-deck contract used by SqliteRepository.
+"""
 
-from deckslots.models import Decklist
-from deckslots.storage import PlaintextRepository, _format_save_file, _get_save_path
+from __future__ import annotations
+
+import pytest
+
+from deckslots.models import CappedCategory, Decklist
+from deckslots.storage import (
+    DecklistRepository,
+    DecklistSummary,
+    PlaintextRepository,
+)
 
 
 def _full_deck() -> Decklist:
-    """Return a Decklist exercising all category types."""
     deck = Decklist.create("Atraxa Stax")
     deck.add_card("Atraxa, Praetors' Voice", "Commander")
-    deck.add_category("Ramp", 8)
+    deck.add_category("Ramp", 10)
     deck.add_card("Sol Ring", "Ramp")
-    deck.add_card("Cultivate", "Ramp")
-    deck.add_category("Removal", 6)
-    deck.add_card("Forest", "Basic Lands")
-    deck.add_card("Forest", "Basic Lands")
-    deck.add_card("Mountain", "Basic Lands")
-    return deck
-
-
-def _deck_no_modes() -> Decklist:
-    deck = Decklist.create("NoneMode")
-    deck.add_card("Atraxa, Praetors' Voice", "Commander")
+    deck.add_card("Arcane Signet", "Ramp")
+    deck.categories["basic lands"].cards.extend(["Plains", "Plains", "Island"])
     return deck
 
 
 def _deck_partners() -> Decklist:
-    deck = Decklist.create("Partners")
+    deck = Decklist.create("Thrasios + Tymna")
     deck.enable_partners()
     deck.add_card("Thrasios, Triton Hero", "Commander")
     deck.add_card("Tymna the Weaver", "Commander")
@@ -34,215 +36,133 @@ def _deck_partners() -> Decklist:
 
 
 def _deck_background() -> Decklist:
-    deck = Decklist.create("Background")
+    deck = Decklist.create("Faceless + Background")
     deck.enable_background()
-    deck.add_card("Syr Armont, the Redeemer", "Commander")
-    deck.add_card("Inspiring Leader", "Commander")
-    return deck
-
-
-def _deck_partners_and_background() -> Decklist:
-    deck = Decklist.create("Both")
-    deck.enable_partners()
-    deck.enable_background()
+    deck.add_card("Faceless One", "Commander")
+    deck.add_card("Cultist of the Absolute", "Commander")
     return deck
 
 
 def _deck_companion() -> Decklist:
-    deck = Decklist.create("Companion")
+    deck = Decklist.create("Lurrus Pile")
     deck.enable_companion()
+    deck.add_card("Kenrith, the Returned King", "Commander")
     deck.add_card("Lurrus of the Dream-Den", "Companion")
-    deck.add_card("Atraxa, Praetors' Voice", "Commander")
     return deck
 
 
-def _deck_with_uncategorized() -> Decklist:
-    deck = Decklist.create("Uncategorized")
-    deck.add_category("Ramp", 2)
-    deck.add_card("Sol Ring", "Ramp")
-    deck.add_card("Arcane Signet", "Ramp")
-    # Trigger Uncategorized creation via remove
-    deck.remove_card("Sol Ring")
-    return deck
+class TestPlaintextRepositoryContract:
+    """PlaintextRepository implements the DecklistRepository protocol."""
 
+    def test_is_a_decklist_repository(self, tmp_path):
+        repo: DecklistRepository = PlaintextRepository(path=tmp_path / "deck.bak")
+        assert hasattr(repo, "save")
+        assert hasattr(repo, "load")
+        assert hasattr(repo, "load_by_name")
+        assert hasattr(repo, "list")
+        assert hasattr(repo, "delete")
 
-# ---------------------------------------------------------------------------
-# PlaintextRepository — save / load
-# ---------------------------------------------------------------------------
+    def test_list_returns_empty_when_no_save_file(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        assert repo.list() == []
 
+    def test_save_returns_int_id(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        deck_id = repo.save(_full_deck())
+        assert isinstance(deck_id, int)
 
-class TestPlaintextRepositorySaveLoad:
-    def test_save_creates_file(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "decklist.bak")
+    def test_save_then_list_returns_one_summary(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
         deck = _full_deck()
-        repo.save(deck)
-        assert (tmp_path / "decklist.bak").exists()
+        deck_id = repo.save(deck)
+        summaries = repo.list()
+        assert len(summaries) == 1
+        s = summaries[0]
+        assert isinstance(s, DecklistSummary)
+        assert s.id == deck_id
+        assert s.name == "Atraxa Stax"
+        assert s.total_filled == deck.total_filled
 
-    def test_save_creates_parent_directories(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "nested" / "dir" / "decklist.bak")
-        repo.save(_deck_no_modes())
-        assert (tmp_path / "nested" / "dir" / "decklist.bak").exists()
-
-    def test_load_returns_none_when_file_missing(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "nonexistent.bak")
-        assert repo.load() is None
-
-    def test_round_trip_preserves_deck_name(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _full_deck()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        assert loaded.name == deck.name
-
-    def test_round_trip_preserves_categories(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _full_deck()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        for key in deck.categories:
-            assert key in loaded.categories
-
-    def test_round_trip_preserves_card_assignments(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _full_deck()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
+    def test_save_then_load_round_trips_full_deck(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        original = _full_deck()
+        deck_id = repo.save(original)
+        loaded = repo.load(deck_id)
+        assert loaded.name == original.name
+        assert "ramp" in loaded.categories
         assert "Sol Ring" in loaded.categories["ramp"].cards
-        assert "Cultivate" in loaded.categories["ramp"].cards
         assert "Atraxa, Praetors' Voice" in loaded.categories["commander"].cards
+        assert sorted(loaded.categories["basic lands"].cards) == [
+            "Island",
+            "Plains",
+            "Plains",
+        ]
 
-    def test_round_trip_preserves_basic_lands(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _full_deck()
-        repo.save(deck)
-        loaded = repo.load()
+    def test_load_raises_keyerror_when_save_missing(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "missing.bak")
+        with pytest.raises(KeyError):
+            repo.load(1)
+
+    def test_load_by_name_returns_none_when_save_missing(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "missing.bak")
+        assert repo.load_by_name("Anything") is None
+
+    def test_load_by_name_returns_deck_when_name_matches(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        repo.save(_full_deck())
+        loaded = repo.load_by_name("Atraxa Stax")
         assert loaded is not None
-        assert loaded.categories["basic lands"].filled == 3
+        assert loaded.name == "Atraxa Stax"
 
-    def test_round_trip_no_mode_flags(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _deck_no_modes()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        assert not loaded.partners_enabled
-        assert not loaded.background_enabled
-        assert not loaded.companion_enabled
+    def test_load_by_name_returns_none_when_name_differs(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        repo.save(_full_deck())
+        assert repo.load_by_name("Other") is None
 
-    def test_round_trip_partners_mode(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _deck_partners()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        assert loaded.categories["commander"].filled == 2
-
-    def test_round_trip_background_mode(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _deck_background()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        assert loaded.categories["commander"].filled == 2
-
-    def test_round_trip_companion_mode(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _deck_companion()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        assert "companion" in loaded.categories
-        assert "Lurrus of the Dream-Den" in loaded.categories["companion"].cards
-
-    def test_round_trip_with_uncategorized(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "deck.bak")
-        deck = _deck_with_uncategorized()
-        repo.save(deck)
-        loaded = repo.load()
-        assert loaded is not None
-        assert "uncategorized" in loaded.categories
-        assert "Sol Ring" in loaded.categories["uncategorized"].cards
-
-
-# ---------------------------------------------------------------------------
-# PlaintextRepository — delete
-# ---------------------------------------------------------------------------
-
-
-class TestPlaintextRepositoryDelete:
-    def test_delete_removes_file(self, tmp_path):
+    def test_delete_removes_save_file(self, tmp_path):
         path = tmp_path / "deck.bak"
-        repo = PlaintextRepository(path)
-        repo.save(_deck_no_modes())
-        assert path.exists()
-        repo.delete()
+        repo = PlaintextRepository(path=path)
+        deck_id = repo.save(_full_deck())
+        repo.delete(deck_id)
         assert not path.exists()
+        assert repo.list() == []
 
     def test_delete_is_idempotent_when_file_missing(self, tmp_path):
-        repo = PlaintextRepository(tmp_path / "nonexistent.bak")
-        repo.delete()  # should not raise
+        repo = PlaintextRepository(path=tmp_path / "missing.bak")
+        repo.delete(1)  # should not raise
 
+    def test_round_trip_preserves_partners(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        deck_id = repo.save(_deck_partners())
+        loaded = repo.load(deck_id)
+        commander = loaded.categories["commander"]
+        assert isinstance(commander, CappedCategory)
+        assert commander.total_slots == 2
+        assert len(commander.cards) == 2
 
-# ---------------------------------------------------------------------------
-# PlaintextRepository — default path from XDG
-# ---------------------------------------------------------------------------
+    def test_round_trip_preserves_background(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        deck_id = repo.save(_deck_background())
+        loaded = repo.load(deck_id)
+        commander = loaded.categories["commander"]
+        assert isinstance(commander, CappedCategory)
+        assert commander.total_slots == 2
+
+    def test_round_trip_preserves_companion(self, tmp_path):
+        repo = PlaintextRepository(path=tmp_path / "deck.bak")
+        deck_id = repo.save(_deck_companion())
+        loaded = repo.load(deck_id)
+        assert "companion" in loaded.categories
+        assert loaded.categories["companion"].cards == [
+            "Lurrus of the Dream-Den"
+        ]
 
 
 class TestPlaintextRepositoryDefaultPath:
-    def test_default_path_uses_xdg_state_home(self, monkeypatch, tmp_path):
+    def test_default_path_uses_xdg_state_home(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
         repo = PlaintextRepository()
-        repo.save(_deck_no_modes())
-        assert (tmp_path / "deckslots" / "decklist.bak").exists()
-
-    def test_default_path_falls_back_to_home(self, monkeypatch, tmp_path):
-        from pathlib import Path
-
-        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
-        expected = Path.home() / ".local" / "state" / "deckslots" / "decklist.bak"
-        repo = PlaintextRepository()
-        assert repo._path == expected
-
-
-# ---------------------------------------------------------------------------
-# _get_save_path (moved to storage.py)
-# ---------------------------------------------------------------------------
-
-
-class TestGetSavePath:
-    def test_default_uses_home(self, monkeypatch):
-        from pathlib import Path
-
-        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
-        path = _get_save_path()
-        assert path == Path.home() / ".local" / "state" / "deckslots" / "decklist.bak"
-
-    def test_respects_xdg_state_home(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-        path = _get_save_path()
-        assert path == tmp_path / "deckslots" / "decklist.bak"
-
-
-# ---------------------------------------------------------------------------
-# _format_save_file (moved to storage.py — spot-check)
-# ---------------------------------------------------------------------------
-
-
-class TestFormatSaveFileInStorage:
-    def test_first_line_is_name_comment(self):
-        deck = Decklist.create("My Deck")
-        lines = _format_save_file(deck).splitlines()
-        assert lines[0] == "# My Deck"
-
-    def test_commander_section_written(self):
-        deck = _full_deck()
-        content = _format_save_file(deck)
-        assert "Commander\n1 Atraxa, Praetors' Voice" in content
-
-    def test_user_defined_category_heading_includes_slot_count(self):
-        deck = _full_deck()
-        content = _format_save_file(deck)
-        assert "Ramp [8 slots]" in content
+        deck_id = repo.save(_full_deck())
+        expected = tmp_path / "deckslots" / "decklist.bak"
+        assert expected.exists()
+        assert repo.load(deck_id).name == "Atraxa Stax"

--- a/tests/test_storage_repository.py
+++ b/tests/test_storage_repository.py
@@ -153,9 +153,7 @@ class TestPlaintextRepositoryContract:
         deck_id = repo.save(_deck_companion())
         loaded = repo.load(deck_id)
         assert "companion" in loaded.categories
-        assert loaded.categories["companion"].cards == [
-            "Lurrus of the Dream-Den"
-        ]
+        assert loaded.categories["companion"].cards == ["Lurrus of the Dream-Den"]
 
 
 class TestPlaintextRepositoryDefaultPath:

--- a/tests/test_storage_repository.py
+++ b/tests/test_storage_repository.py
@@ -304,6 +304,51 @@ class TestSqliteSchemaMigration:
         assert count == 1
 
 
+class TestSqliteRepositoryLegacyImport:
+    """First-run convenience: import an existing decklist.bak into a fresh db."""
+
+    def test_legacy_bak_imported_on_first_open(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+        legacy = tmp_path / "state" / "deckslots" / "decklist.bak"
+        legacy.parent.mkdir(parents=True)
+        PlaintextRepository(path=legacy).save(_full_deck())
+        repo = SqliteRepository(path=tmp_path / "library.db")
+        summaries = repo.list()
+        assert len(summaries) == 1
+        assert summaries[0].name == "Atraxa Stax"
+        loaded = repo.load(summaries[0].id)
+        assert "Sol Ring" in loaded.categories["ramp"].cards
+
+    def test_legacy_bak_preserved_after_import(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+        legacy = tmp_path / "state" / "deckslots" / "decklist.bak"
+        legacy.parent.mkdir(parents=True)
+        PlaintextRepository(path=legacy).save(_full_deck())
+        SqliteRepository(path=tmp_path / "library.db")
+        assert legacy.exists()
+
+    def test_legacy_not_imported_when_db_already_has_decks(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+        legacy = tmp_path / "state" / "deckslots" / "decklist.bak"
+        legacy.parent.mkdir(parents=True)
+        PlaintextRepository(path=legacy).save(_full_deck())
+        db_path = tmp_path / "library.db"
+        repo = SqliteRepository(path=db_path)
+        repo.delete(repo.list()[0].id)  # remove the imported deck
+        repo.save(_deck_partners())
+        # Reopen: should NOT re-import the legacy deck
+        repo2 = SqliteRepository(path=db_path)
+        names = {s.name for s in repo2.list()}
+        assert names == {"Thrasios + Tymna"}
+
+    def test_no_legacy_file_is_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+        repo = SqliteRepository(path=tmp_path / "library.db")
+        assert repo.list() == []
+
+
 class TestSqliteRepositoryDefaultPath:
     def test_default_path_uses_xdg_data_home(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))

--- a/tests/test_storage_repository.py
+++ b/tests/test_storage_repository.py
@@ -14,6 +14,7 @@ from deckslots.storage import (
     DecklistRepository,
     DecklistSummary,
     PlaintextRepository,
+    SqliteRepository,
 )
 
 
@@ -162,5 +163,152 @@ class TestPlaintextRepositoryDefaultPath:
         repo = PlaintextRepository()
         deck_id = repo.save(_full_deck())
         expected = tmp_path / "deckslots" / "decklist.bak"
+        assert expected.exists()
+        assert repo.load(deck_id).name == "Atraxa Stax"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.2 — SqliteRepository contract (parametrized round-trips)
+# ---------------------------------------------------------------------------
+
+
+def _make_repos(tmp_path):
+    return {
+        "plaintext": PlaintextRepository(path=tmp_path / "deck.bak"),
+        "sqlite": SqliteRepository(path=tmp_path / "library.db"),
+    }
+
+
+@pytest.fixture(params=["plaintext", "sqlite"])
+def repo(request, tmp_path):
+    return _make_repos(tmp_path)[request.param]
+
+
+class TestRepositoryContractParametrized:
+    """Both backends must honour the same DecklistRepository contract."""
+
+    def test_empty_repo_lists_nothing(self, repo):
+        assert repo.list() == []
+
+    def test_save_then_load_round_trips_full_deck(self, repo):
+        original = _full_deck()
+        deck_id = repo.save(original)
+        loaded = repo.load(deck_id)
+        assert loaded.name == original.name
+        assert "ramp" in loaded.categories
+        assert "Sol Ring" in loaded.categories["ramp"].cards
+        assert "Atraxa, Praetors' Voice" in loaded.categories["commander"].cards
+        assert sorted(loaded.categories["basic lands"].cards) == [
+            "Island",
+            "Plains",
+            "Plains",
+        ]
+
+    def test_save_then_list_returns_summary(self, repo):
+        deck = _full_deck()
+        deck_id = repo.save(deck)
+        summaries = repo.list()
+        assert len(summaries) == 1
+        s = summaries[0]
+        assert s.id == deck_id
+        assert s.name == "Atraxa Stax"
+        assert s.total_filled == deck.total_filled
+
+    def test_round_trip_preserves_partners(self, repo):
+        deck_id = repo.save(_deck_partners())
+        loaded = repo.load(deck_id)
+        commander = loaded.categories["commander"]
+        assert isinstance(commander, CappedCategory)
+        assert commander.total_slots == 2
+        assert len(commander.cards) == 2
+
+    def test_round_trip_preserves_background(self, repo):
+        deck_id = repo.save(_deck_background())
+        loaded = repo.load(deck_id)
+        commander = loaded.categories["commander"]
+        assert isinstance(commander, CappedCategory)
+        assert commander.total_slots == 2
+
+    def test_round_trip_preserves_companion(self, repo):
+        deck_id = repo.save(_deck_companion())
+        loaded = repo.load(deck_id)
+        assert "companion" in loaded.categories
+        assert loaded.categories["companion"].cards == ["Lurrus of the Dream-Den"]
+
+    def test_load_by_name_returns_deck_or_none(self, repo):
+        repo.save(_full_deck())
+        assert repo.load_by_name("Atraxa Stax").name == "Atraxa Stax"
+        assert repo.load_by_name("Other") is None
+
+    def test_load_missing_id_raises_keyerror(self, repo):
+        with pytest.raises(KeyError):
+            repo.load(999)
+
+    def test_delete_removes_deck(self, repo):
+        deck_id = repo.save(_full_deck())
+        repo.delete(deck_id)
+        assert repo.list() == []
+
+
+class TestSqliteRepositoryMultiDeck:
+    """SQLite-specific: multiple decks coexist; ids and names are independent."""
+
+    def test_save_two_decks_returns_distinct_ids(self, tmp_path):
+        repo = SqliteRepository(path=tmp_path / "library.db")
+        id_a = repo.save(_full_deck())
+        id_b = repo.save(_deck_partners())
+        assert id_a != id_b
+        names = {s.name for s in repo.list()}
+        assert names == {"Atraxa Stax", "Thrasios + Tymna"}
+
+    def test_save_same_name_upserts(self, tmp_path):
+        repo = SqliteRepository(path=tmp_path / "library.db")
+        deck = _full_deck()
+        id_a = repo.save(deck)
+        deck.add_card("Cultivate", "Ramp")
+        id_b = repo.save(deck)
+        assert id_a == id_b
+        assert len(repo.list()) == 1
+        reloaded = repo.load(id_b)
+        assert "Cultivate" in reloaded.categories["ramp"].cards
+
+    def test_delete_only_removes_target_deck(self, tmp_path):
+        repo = SqliteRepository(path=tmp_path / "library.db")
+        id_a = repo.save(_full_deck())
+        id_b = repo.save(_deck_partners())
+        repo.delete(id_a)
+        remaining = [s.id for s in repo.list()]
+        assert remaining == [id_b]
+
+
+class TestSqliteSchemaMigration:
+    def test_fresh_db_applies_schema_version_1(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "library.db"
+        SqliteRepository(path=db_path)
+        with sqlite3.connect(str(db_path)) as conn:
+            cur = conn.execute("SELECT version FROM schema_version")
+            rows = cur.fetchall()
+        assert rows == [(1,)]
+
+    def test_reopen_does_not_reapply_migration(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "library.db"
+        SqliteRepository(path=db_path)
+        SqliteRepository(path=db_path)  # second open
+        with sqlite3.connect(str(db_path)) as conn:
+            cur = conn.execute("SELECT COUNT(*) FROM schema_version")
+            (count,) = cur.fetchone()
+        assert count == 1
+
+
+class TestSqliteRepositoryDefaultPath:
+    def test_default_path_uses_xdg_data_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        repo = SqliteRepository()
+        deck_id = repo.save(_full_deck())
+        expected = tmp_path / "deckslots" / "library.db"
         assert expected.exists()
         assert repo.load(deck_id).name == "Atraxa Stax"

--- a/tests/test_storage_repository.py
+++ b/tests/test_storage_repository.py
@@ -327,9 +327,7 @@ class TestSqliteRepositoryLegacyImport:
         SqliteRepository(path=tmp_path / "library.db")
         assert legacy.exists()
 
-    def test_legacy_not_imported_when_db_already_has_decks(
-        self, tmp_path, monkeypatch
-    ):
+    def test_legacy_not_imported_when_db_already_has_decks(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
         legacy = tmp_path / "state" / "deckslots" / "decklist.bak"
         legacy.parent.mkdir(parents=True)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -125,9 +125,7 @@ class TestLoadAllTemplates:
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
         user_dir = tmp_path / "deckslots" / "templates"
         user_dir.mkdir(parents=True)
-        (user_dir / "my-template.tmpl").write_text(
-            "# My Template\nRamp [10 slots]\n"
-        )
+        (user_dir / "my-template.tmpl").write_text("# My Template\nRamp [10 slots]\n")
         templates = load_all_templates()
         names = [t.name for t in templates]
         assert "My Template" in names


### PR DESCRIPTION
## Summary

- **`storage.py` — storage seam**: `DecklistRepository` Protocol (5 methods: `save`, `load`, `load_by_name`, `list`, `delete`), `DecklistSummary` frozen dataclass, `PlaintextRepository` (single-file backend, synthetic ID=1), `SqliteRepository` (multi-deck backend, `library.db`, hand-rolled schema migrations, legacy `decklist.bak` import on first open)
- **`config.py`**: `get_storage_backend()` reads `{"storage_backend": "plaintext"|"sqlite"}` from `config.json`; defaults to `"plaintext"`
- **`cli/repl.py`**: `_build_repository()` selects backend from config at startup; startup logic uses `list()` + `load(id)` instead of the old `load()` call
- **`cli/commands.py`**: `Session.repository: DecklistRepository`; `handle_decklist_save/load` route through the repository; new `handle_decklist_list`, `handle_decklist_switch`, `handle_decklist_delete` handlers; backward-compat re-exports of storage helpers for existing tests
- **Tests**: `tests/test_storage_repository.py` (full contract suite for both backends, legacy import, schema migration, XDG paths), `TestDecklistListHandler`, `TestDecklistSwitchHandler`, `TestDecklistDeleteHandler`, `TestMultiDeckCommandsRegistered` in `test_commands.py`, `TestStorageBackendSelection` + `TestConfig` additions in `test_scryfall.py`
- **`tests/functional/01-startup.md`**: updated `help` output to include `decklist list`, `decklist switch`, `decklist delete`
- **`src/deckslots/CLAUDE.md`**: updated architecture docs for the new storage seam and multi-deck commands

## Architecture notes

- `PlaintextRepository` implements the full 5-method protocol with `id=1` everywhere; `list()` tolerates corrupt files so the REPL can detect corruption via `load()` and offer recovery
- `SqliteRepository._maybe_import_legacy()` seeds an empty database from `decklist.bak` on first open, preserving the plaintext file as a read-only fallback
- Both backends work with `decklist list/switch/delete`; Plaintext just sees a one-element library

## Test plan

- [ ] `uv run pytest` — 750 tests pass
- [ ] `uv run ruff check .` — clean
- [ ] Start REPL with no config (`uv run deckslots`) → uses `PlaintextRepository`, resumes from `decklist.bak` if present
- [ ] Start REPL with `{"storage_backend": "sqlite"}` in config → uses `SqliteRepository`, imports `decklist.bak` on first run
- [ ] `decklist list` shows saved decks; `decklist switch <name>` loads one; `decklist delete <name>` prompts and removes

https://claude.ai/code/session_01KysBW83NXrvy14KZqN8D4J

---
_Generated by [Claude Code](https://claude.ai/code/session_01KysBW83NXrvy14KZqN8D4J)_