### PR TITLE
docs: add Phase 4 packaging and GUI feature design plans

### DIFF
--- a/docs/plans/2026-05-13-add-category-gui.md
+++ b/docs/plans/2026-05-13-add-category-gui.md
@@ -1,0 +1,88 @@
+# Design: "Add Category" Dialog (GUI)
+
+The `+ Category` button in the toolbar is currently a no-op. Without it, users
+cannot create new categories from the GUI at all — they would need to use the REPL
+first and then open the GUI. This makes the GUI useless as a standalone deckbuilding
+tool.
+
+## Goals
+
+- Wire the `+ Category` toolbar action to a modal dialog.
+- Validate name (non-empty, unique) and slot count (1–99) before enabling OK.
+- Route the creation through `services.create_category()` so all domain invariants
+  are enforced identically to the REPL.
+- Emit `deck_mutated` so the board refreshes and the new tile appears.
+
+## Non-goals
+
+- Inline-add (editing directly in the masonry grid). A modal is simpler and
+  consistent with the rename flow.
+- Preset templates from the dialog. Template application is a separate `Deck` menu
+  item.
+
+## Design
+
+### New class: `_AddCategoryDialog` in `src/deckslots/gui/main_window.py`
+
+A `QDialog` subclass with two fields:
+
+| Field | Widget | Constraints |
+|-------|--------|-------------|
+| Category name | `QLineEdit` | Required; trimmed; must not match an existing category name (case-insensitive) |
+| Number of slots | `QSpinBox` | Range 1–99; default 8 |
+
+OK button is disabled until the name field is non-empty and valid. Duplicate-name
+check fires on every `textChanged` signal and shows an inline red error label.
+
+```python
+class _AddCategoryDialog(QDialog):
+    def __init__(self, existing_names: set[str], parent=None) -> None: ...
+    # Returns (name, slots) on accept; caller reads .result()
+    @property
+    def category_name(self) -> str: ...
+    @property
+    def slot_count(self) -> int: ...
+```
+
+### Wiring in `src/deckslots/gui/main_window.py`
+
+`DeckWindow` already builds the toolbar. Find the `+ Category` action and connect it:
+
+```python
+# In DeckWindow._build_toolbar() or __init__:
+add_cat_action.triggered.connect(self._on_add_category)
+
+def _on_add_category(self) -> None:
+    existing = {name.lower() for name in self._deck.categories}
+    dlg = _AddCategoryDialog(existing, parent=self)
+    if dlg.exec() != QDialog.Accepted:
+        return
+    result = services.create_category(self._deck, dlg.category_name, dlg.slot_count)
+    if result.ok:
+        self._board.refresh(result.events)
+        self._repo.save(self._deck)
+    else:
+        QMessageBox.warning(self, "Add Category", result.message)
+```
+
+`services.create_category` already validates name length, uniqueness, and slot range
+(1–99) and returns a `CommandResult`. The dialog pre-validates for responsiveness, but
+the service is the authoritative gate.
+
+## Testing strategy
+
+- **Unit** (`tests/gui/test_main_window.py`):
+  - Trigger `_on_add_category` with a mock dialog that accepts → assert
+    `services.create_category` is called and `deck_mutated` is emitted.
+  - Trigger with a mock dialog that rejects → assert no service call.
+- **Widget** (`tests/gui/test_main_window.py`):
+  - Open `_AddCategoryDialog` with an empty name → OK button is disabled.
+  - Enter a duplicate name → error label is visible, OK button is disabled.
+  - Enter a valid name + slots → OK button is enabled; `.category_name` and
+    `.slot_count` return the entered values.
+
+## Critical files
+
+- **Modified**: `src/deckslots/gui/main_window.py` (new `_AddCategoryDialog` class,
+  wire `+ Category` action)
+- **Tests**: `tests/gui/test_main_window.py`

--- a/docs/plans/2026-05-13-gui-import-export.md
+++ b/docs/plans/2026-05-13-gui-import-export.md
@@ -1,0 +1,92 @@
+# Design: Import / Export File Dialogs (GUI)
+
+The `Import…` and `Export…` toolbar buttons are no-ops in the current GUI. In the
+REPL these operations use file-path arguments (`decklist import <path>`, `decklist export <path>`),
+but a packaged desktop app has no command line for the user to type paths. The GUI
+needs `QFileDialog` wrappers that feed into the same underlying format helpers.
+
+## Goals
+
+- Wire `Import…` to open a file picker, parse the selected file via `_parse_import_file`,
+  replace the active deck, save to the repository, and refresh the board.
+- Wire `Export…` to open a save picker defaulting to `<deck_name>.txt`, write the
+  Moxfield-compatible format via `_format_export_file`.
+- Reuse the existing format helpers in `commands.py` unchanged; no new format logic.
+- Surface parse errors as a `QMessageBox.warning` rather than crashing silently.
+
+## Non-goals
+
+- Supporting additional formats (Moxfield JSON, MTGA `.txt`, Decked Builder `.dec`)
+  at this stage. The existing plain-text format covers round-trip with Moxfield and
+  Archidekt. Additional format support is a separate future story.
+- Merging an imported decklist with the active one. Import always replaces, matching
+  REPL semantics.
+
+## Design
+
+Both handlers live in `DeckWindow` in `src/deckslots/gui/main_window.py`.
+
+### Export
+
+```python
+def _on_export(self) -> None:
+    default_name = f"{self._deck.name}.txt"
+    path, _ = QFileDialog.getSaveFileName(
+        self, "Export Deck", default_name, "Text files (*.txt);;All files (*)"
+    )
+    if not path:
+        return
+    from deckslots.cli.commands import _format_export_file
+    text = _format_export_file(self._deck)
+    Path(path).write_text(text, encoding="utf-8")
+    self.statusBar().showMessage(f"Exported to {Path(path).name}", 4000)
+```
+
+### Import
+
+```python
+def _on_import(self) -> None:
+    path, _ = QFileDialog.getOpenFileName(
+        self, "Import Deck", "", "Text files (*.txt);;All files (*)"
+    )
+    if not path:
+        return
+    from deckslots.cli.commands import _parse_import_file
+    try:
+        new_deck = _parse_import_file(Path(path))
+    except Exception as exc:
+        QMessageBox.warning(self, "Import Failed", str(exc))
+        return
+    self._deck = new_deck
+    self._repo.save(self._deck)
+    self._board.set_deck(self._deck)
+    self.statusBar().showMessage(f"Imported "{new_deck.name}"", 4000)
+```
+
+### Wiring
+
+`DeckWindow._build_toolbar()` (or the File menu actions, whichever is wired for these
+buttons) connects the actions:
+
+```python
+import_action.triggered.connect(self._on_import)
+export_action.triggered.connect(self._on_export)
+```
+
+## Testing strategy
+
+- **Unit** (`tests/gui/test_main_window.py`):
+  - Patch `QFileDialog.getSaveFileName` to return a tmp path; assert the file is
+    written and contains the Commander section header.
+  - Patch `QFileDialog.getOpenFileName` to return a fixture decklist path; assert
+    `self._deck.name` changes and `repository.save` is called.
+  - Patch `_parse_import_file` to raise; assert `QMessageBox.warning` is shown and
+    deck is unchanged.
+- **Integration**: export a deck to a temp file, mutate the file, re-import → board
+  reflects the mutation.
+
+## Critical files
+
+- **Modified**: `src/deckslots/gui/main_window.py` (`_on_import`, `_on_export`, toolbar wiring)
+- **No changes** to `src/deckslots/cli/commands.py` — format helpers are reused as-is
+- **Tests**: `tests/gui/test_main_window.py`

--- a/docs/plans/2026-05-13-packaging-phase4.md
+++ b/docs/plans/2026-05-13-packaging-phase4.md
@@ -1,0 +1,227 @@
+# Design: Phase 4 — Packaging and Distribution
+
+`deckslots` currently requires Python 3.12+ and `uv` (or `pip`) to install.
+Shipping to a general user base requires distributable binaries that run without
+any Python toolchain. This plan covers:
+
+1. Font bundling (DM Sans Variable)
+2. Cross-platform path handling (`platformdirs`)
+3. PyInstaller one-file binaries for Windows and macOS
+4. AppImage for Linux
+5. GitHub Actions release CI
+
+## Goals
+
+- A user on Windows, macOS, or Linux can download a single file, double-click it,
+  and `deckslots gui` opens.
+- DM Sans Variable is bundled so the app looks identical on all platforms.
+- File paths on Windows follow `%APPDATA%` / `%LOCALAPPDATA%` conventions.
+- Releases are built automatically when a version tag is pushed.
+
+## Non-goals
+
+- A native macOS `.app` bundle with code-signing and notarization (deferred; add
+  when targeting the Mac App Store).
+- Auto-update within the app (deferred; GitHub Releases provides manual updates).
+- Packaging the CLI-only install (no `[gui]`). The thin REPL remains installable
+  via `pip install deckslots` for power users.
+
+## 1. Font bundling
+
+### Add the font as package data
+
+Download `DM_Sans[opsz,wght].ttf` (SIL Open Font License) and place it at:
+
+```
+src/deckslots/data/fonts/DM_Sans[opsz,wght].ttf
+```
+
+Register it in `pyproject.toml`:
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = ["src/deckslots"]
+# fonts/ is already included because it lives under src/deckslots/data/
+```
+
+### Load via `QFontDatabase` in `styles.py`
+
+```python
+from importlib.resources import files
+
+def _load_dm_sans() -> None:
+    font_path = files("deckslots.data.fonts").joinpath("DM_Sans[opsz,wght].ttf")
+    # importlib.resources returns a Traversable; PyInstaller handles this via its
+    # PKG_RESOURCES hook.
+    with font_path.open("rb") as fh:
+        data = fh.read()
+    from PySide6.QtGui import QFontDatabase
+    from PySide6.QtCore import QByteArray
+    QFontDatabase.addApplicationFontFromData(QByteArray(data))
+```
+
+Call `_load_dm_sans()` at the top of `apply_theme()` before setting the stylesheet.
+The `system-ui` fallback in the stylesheet remains as a safety net.
+
+## 2. Cross-platform path handling
+
+Replace the manual XDG env-var checks in `config.py`, `storage.py`, and
+`scryfall.py` with `platformdirs`:
+
+```toml
+[project.optional-dependencies]
+gui = [
+    "pyside6>=6.6",
+    "platformdirs>=4.0",
+]
+```
+
+`platformdirs` is also useful for the CLI on macOS (returns `~/Library/…` paths);
+add it as a core dependency rather than a `[gui]`-only one.
+
+```python
+# config.py — before
+xdg = os.environ.get("XDG_CONFIG_HOME")
+base = Path(xdg) if xdg else Path.home() / ".config"
+
+# config.py — after
+from platformdirs import user_config_dir
+base = Path(user_config_dir("deckslots", appauthor=False))
+```
+
+Apply the same change in `storage.py` (`user_state_dir`, `user_data_dir`) and
+`scryfall.py` (`user_cache_dir`). The XDG env-var overrides used in tests can be
+replaced with `platformdirs`'s `PlatformDirs(…, multipath=False)` or by monkey-
+patching the `platformdirs` functions in test fixtures.
+
+## 3. PyInstaller spec
+
+New file `packaging/deckslots.spec`:
+
+```python
+# packaging/deckslots.spec
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("deckslots")   # picks up data/templates/ and data/fonts/
+
+a = Analysis(
+    ["src/deckslots/cli/__init__.py"],
+    pathex=[],
+    datas=datas,
+    hiddenimports=["deckslots.gui"],       # lazy import in cli.py
+)
+pyz = PYZ(a.pure, a.zipped_data)
+exe = EXE(pyz, a.scripts, a.binaries, a.zipfiles, a.datas,
+          name="deckslots", console=False, onefile=True)
+```
+
+Build command (run in repo root with the `[gui]` extra installed):
+
+```bash
+uv run pyinstaller packaging/deckslots.spec --distpath dist/
+```
+
+`console=False` hides the terminal window on Windows (GUI-only). The REPL will not
+work from this binary — that is acceptable; power users use `pip install deckslots`.
+
+## 4. AppImage (Linux)
+
+New script `packaging/build-appimage.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+# 1. Build the PyInstaller one-dir output
+uv run pyinstaller packaging/deckslots.spec --onedir --distpath /tmp/appimage-stage/usr/bin/
+# 2. Create AppDir structure
+mkdir -p /tmp/AppDir/usr/{bin,share/applications,share/icons}
+cp -r /tmp/appimage-stage/usr/bin/deckslots /tmp/AppDir/usr/bin/
+cp packaging/deckslots.desktop /tmp/AppDir/usr/share/applications/
+cp packaging/deckslots-256.png /tmp/AppDir/usr/share/icons/
+# 3. Build the AppImage
+appimagetool /tmp/AppDir dist/deckslots-linux-x86_64.AppImage
+```
+
+Requires `appimagetool` (downloaded by CI; not a repo dependency).
+
+## 5. GitHub Actions release CI
+
+New file `.github/workflows/release.yml`:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --extra gui
+      - run: uv run pyinstaller packaging/deckslots.spec
+      - run: bash packaging/build-appimage.sh
+      - uses: actions/upload-artifact@v4
+        with: { name: linux, path: dist/*.AppImage }
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --extra gui
+      - run: uv run pyinstaller packaging/deckslots.spec
+      - uses: actions/upload-artifact@v4
+        with: { name: windows, path: dist/deckslots.exe }
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --extra gui
+      - run: uv run pyinstaller packaging/deckslots.spec
+      - uses: actions/upload-artifact@v4
+        with: { name: macos, path: dist/deckslots }
+
+  release:
+    needs: [build-linux, build-windows, build-macos]
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/download-artifact@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            linux/*.AppImage
+            windows/deckslots.exe
+            macos/deckslots
+```
+
+## Testing strategy
+
+- **Font loading**: unit test in `tests/gui/test_styles.py` — call `apply_theme()`
+  with a real `QApplication`; assert the DM Sans family is in
+  `QFontDatabase.families()`.
+- **platformdirs paths**: parametrize existing path tests in `tests/test_config.py`,
+  `tests/test_storage_repository.py`, and `tests/test_scryfall.py` to set
+  `platformdirs` env overrides instead of XDG env vars.
+- **Smoke binary**: after a local PyInstaller build, run `dist/deckslots --help`
+  and `dist/deckslots gui` (headless with `QT_QPA_PLATFORM=offscreen`) in CI.
+
+## Critical files
+
+- **New**: `packaging/deckslots.spec`, `packaging/build-appimage.sh`,
+  `packaging/deckslots.desktop`, `packaging/deckslots-256.png`,
+  `.github/workflows/release.yml`,
+  `src/deckslots/data/fonts/DM_Sans[opsz,wght].ttf`
+- **Modified**: `src/deckslots/gui/styles.py` (`_load_dm_sans`, `apply_theme`),
+  `src/deckslots/config.py` (platformdirs),
+  `src/deckslots/storage.py` (platformdirs),
+  `src/deckslots/scryfall.py` (platformdirs),
+  `pyproject.toml` (add `platformdirs>=4.0` dependency)
+- **Tests**: `tests/gui/test_styles.py`, `tests/test_config.py`,
+  `tests/test_storage_repository.py`, `tests/test_scryfall.py`

--- a/docs/plans/2026-05-13-scryfall-first-run-gui.md
+++ b/docs/plans/2026-05-13-scryfall-first-run-gui.md
@@ -1,0 +1,125 @@
+# Design: Scryfall First-Run Download Flow (GUI)
+
+The REPL prompts users once at startup when the oracle card cache is absent or
+stale (> 7 days). The GUI has no equivalent flow. A user who installs the `[gui]`
+extra and launches `deckslots gui` for the first time gets:
+
+- No card-name validation (omnibar search returns nothing).
+- No Scryfall card images.
+- No indication anything is wrong.
+
+This plan introduces a non-blocking background download triggered at GUI startup,
+with status bar feedback.
+
+## Goals
+
+- On GUI launch, check whether the oracle card cache is absent or stale.
+- If stale: start a background `QRunnable` worker that downloads the bulk data
+  without blocking the main thread or delaying deck load.
+- Show a status bar message while the download is in progress and on completion
+  (or failure).
+- Pass the loaded index to `DeckWindow` and `ImageLoader` once the download
+  completes so omnibar search and card images work.
+
+## Non-goals
+
+- Blocking the app on the download. The deck loads and is usable immediately;
+  card search improves once the index is ready.
+- A progress bar with byte counts. A spinner / text message in the status bar is
+  sufficient.
+- Forcing a re-download if the user is offline. The worker catches network errors
+  and shows a non-fatal status message.
+
+## Design
+
+### New class: `_ScryfallWorker` in `src/deckslots/gui/app.py`
+
+```python
+from PySide6.QtCore import QObject, QRunnable, Signal
+
+class _WorkerSignals(QObject):
+    finished = Signal(dict)   # emits the loaded index on success
+    failed = Signal(str)      # emits an error message on failure
+
+class _ScryfallWorker(QRunnable):
+    def __init__(self) -> None:
+        super().__init__()
+        self.signals = _WorkerSignals()
+
+    def run(self) -> None:
+        try:
+            from deckslots import scryfall
+            cache = scryfall.get_cache_path()
+            scryfall.download_oracle_cards(cache)
+            index = scryfall.load_index_from_cache(cache) or {}
+            self.signals.finished.emit(index)
+        except Exception as exc:
+            self.signals.failed.emit(str(exc))
+```
+
+### Wiring in `run_app()`
+
+```python
+def run_app(exec_loop: bool = True) -> None:
+    ...
+    window = DeckWindow(deck, repo)
+    window.show()
+
+    # Non-blocking Scryfall refresh
+    from deckslots import scryfall
+    cache = scryfall.get_cache_path()
+    if scryfall.is_cache_stale(cache):
+        worker = _ScryfallWorker()
+        worker.signals.finished.connect(window.on_scryfall_ready)
+        worker.signals.failed.connect(window.on_scryfall_failed)
+        window.statusBar().showMessage("Updating card index…")
+        QThreadPool.globalInstance().start(worker)
+    else:
+        index = scryfall.load_index_from_cache(cache) or {}
+        if index:
+            window.on_scryfall_ready(index)
+    ...
+```
+
+### New slots in `DeckWindow`
+
+```python
+def on_scryfall_ready(self, index: dict) -> None:
+    self._scryfall_index = index
+    self._board.set_scryfall_index(index)   # forwards to ImageLoader + Omnibar
+    self.statusBar().showMessage("Card index ready", 4000)
+
+def on_scryfall_failed(self, message: str) -> None:
+    self.statusBar().showMessage("Card index unavailable (offline?)", 6000)
+```
+
+`BoardWidget.set_scryfall_index(index)` passes the index to `ImageLoader` and
+`Omnibar` so they can begin operating. Both already accept `None` gracefully —
+images show the placeholder, omnibar shows no results — so no behaviour changes
+for the zero-index case.
+
+## Testing strategy
+
+- **Unit** (`tests/gui/test_app.py`):
+  - Patch `scryfall.is_cache_stale` → True; assert `_ScryfallWorker` is submitted
+    to `QThreadPool` and status bar shows "Updating card index…".
+  - Patch `is_cache_stale` → False with a non-empty index; assert
+    `window.on_scryfall_ready` is called synchronously with the index.
+- **Unit** (`tests/gui/test_main_window.py`):
+  - `on_scryfall_ready(index)` → `_scryfall_index` is set and status bar message
+    matches.
+  - `on_scryfall_failed("timeout")` → status bar shows the unavailable message.
+- **Worker unit** (`tests/gui/test_app.py`):
+  - Patch `scryfall.download_oracle_cards` to succeed; assert `signals.finished`
+    emits a non-empty dict.
+  - Patch `download_oracle_cards` to raise `OSError`; assert `signals.failed`
+    emits a non-empty string.
+
+## Critical files
+
+- **Modified**: `src/deckslots/gui/app.py` (new `_ScryfallWorker`, launch logic)
+- **Modified**: `src/deckslots/gui/main_window.py` (new `on_scryfall_ready`,
+  `on_scryfall_failed` slots; `_scryfall_index` field)
+- **Modified**: `src/deckslots/gui/board_widget.py` (`set_scryfall_index` method
+  forwarding to `ImageLoader` and `Omnibar`)
+- **Tests**: `tests/gui/test_app.py`, `tests/gui/test_main_window.py`

--- a/docs/plans/2026-05-13-sqlite-default-gui.md
+++ b/docs/plans/2026-05-13-sqlite-default-gui.md
@@ -1,0 +1,69 @@
+# Design: SQLite as Default Backend for the GUI
+
+The GUI (`deckslots gui`) should always use `SqliteRepository` regardless of the
+`storage_backend` setting in `config.json`. The multi-deck workflow — deck library
+panel, switching, deleting — is the *only* workflow the GUI offers; it makes no
+sense to open the GUI and land on a single-file `PlaintextRepository` that shows
+no deck library panel and has no deck-switching affordance.
+
+The REPL path is unchanged: it continues to honour `config.get_storage_backend()`
+and defaults to `"plaintext"`.
+
+## Goals
+
+- `deckslots gui` always uses `SqliteRepository`, with no config.json required.
+- A user coming from the REPL with a `decklist.bak` gets their deck auto-imported
+  into the database on first GUI launch (already handled by `_maybe_import_legacy()`).
+- CLI / REPL users are unaffected — their default stays `PlaintextRepository`.
+
+## Non-goals
+
+- Removing the `storage_backend` config key. The REPL still respects it.
+- Showing a backend-picker dialog. The GUI always uses SQLite.
+
+## Design
+
+### `src/deckslots/gui/app.py`
+
+Replace the current backend selection in `run_app()`:
+
+```python
+# Before (reads config, may return PlaintextRepository):
+repo = _pick_repository()
+
+# After (always SQLite for the GUI):
+from deckslots.storage import SqliteRepository
+repo = SqliteRepository()
+```
+
+`SqliteRepository.__init__` already calls `_maybe_import_legacy()`, which seeds the
+database from any existing `decklist.bak` exactly once (when the DB is empty). No
+additional migration code is needed.
+
+### First-launch experience
+
+| Scenario | Result |
+|----------|--------|
+| Brand-new install, no `decklist.bak` | Empty library; `run_app()` creates a `"New Deck"` as before |
+| Existing `decklist.bak`, no `library.db` | `_maybe_import_legacy()` imports the deck; user sees it in the library panel |
+| Existing `library.db` already | Normal open; legacy import is a no-op |
+
+## Testing strategy
+
+- **Unit** (`tests/gui/test_app.py`): patch `SqliteRepository` and assert `run_app()`
+  constructs it without reading `config.get_storage_backend()`.
+- **Integration**: run `deckslots gui` from a clean XDG temp directory containing
+  only a `decklist.bak`; assert `library.db` is created and the imported deck loads.
+
+## Backwards compatibility
+
+REPL users (`deckslots` with no subcommand) are unaffected. The `storage_backend`
+config key retains its meaning for the REPL. GUI users who previously set
+`{"storage_backend": "plaintext"}` to force plaintext in the GUI will now always
+get SQLite; this is intentional — the plaintext backend cannot support the GUI deck
+library panel.
+
+## Critical files
+
+- **Modified**: `src/deckslots/gui/app.py` (remove `_pick_repository()` call, hard-code `SqliteRepository`)
+- **Tests**: `tests/gui/test_app.py`


### PR DESCRIPTION
Add four comprehensive design documents outlining the next phase of `deckslots` development:

## Summary

These plans detail the path to shipping `deckslots` as a standalone desktop application with a complete GUI feature set. They cover packaging for distribution, first-run Scryfall sync, import/export workflows, category creation, and SQLite as the default backend for the GUI.

## Design Documents Added

1. **`2026-05-13-packaging-phase4.md`** — Packaging and distribution strategy
   - Font bundling (DM Sans Variable via `importlib.resources`)
   - Cross-platform path handling with `platformdirs`
   - PyInstaller one-file binaries for Windows and macOS
   - AppImage for Linux
   - GitHub Actions release CI (automated builds on version tags)
   - Testing strategy for font loading, paths, and smoke tests

2. **`2026-05-13-scryfall-first-run-gui.md`** — Non-blocking Scryfall cache sync
   - Background `QRunnable` worker for oracle card downloads
   - Status bar feedback during download
   - Graceful fallback if offline
   - Passes loaded index to `DeckWindow` and `ImageLoader` on completion

3. **`2026-05-13-gui-import-export.md`** — File dialog wrappers for import/export
   - `QFileDialog` integration for open/save workflows
   - Reuses existing `_parse_import_file` and `_format_export_file` helpers
   - Error handling via `QMessageBox.warning`
   - Supports round-trip with Moxfield-compatible plain-text format

4. **`2026-05-13-add-category-gui.md`** — Modal dialog for category creation
   - `_AddCategoryDialog` with name and slot-count fields
   - Real-time validation (non-empty, unique, 1–99 slots)
   - Routes through `services.create_category()` for domain invariant enforcement
   - Emits `deck_mutated` to refresh the board

5. **`2026-05-13-sqlite-default-gui.md`** — SQLite as default backend for GUI
   - `deckslots gui` always uses `SqliteRepository` (no config.json required)
   - REPL continues to honour `storage_backend` config
   - Auto-imports legacy `decklist.bak` on first GUI launch
   - Enables multi-deck library workflow in the GUI

## Implementation Notes

- All designs follow TDD methodology (failing test → minimal code → refactor)
- Testing strategies are detailed for each feature (unit, widget, integration)
- Critical files and modification points are listed for each plan
- Designs reuse existing domain logic (`services`, `commands`, `scryfall` modules) to avoid duplication
- GUI designs align with the hi-fi prototype in `docs/design/Big Bridge Energy.html`

These plans are ready for implementation as separate feature branches and PRs.

https://claude.ai/code/session_01SmxGiWBiPnEKwV5FVkapzF