### PR TITLE
chore: allow git tag and version-tag push without permission prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git tag *)",
+      "Bash(git push origin v*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
Adds `Bash(git tag *)` and `Bash(git push origin v*)` to `.claude/settings.json` permissions allow-list so Claude Code doesn't prompt for confirmation when creating or pushing version tags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtDWjyPEGQwvDZ1ijRQ1dA)_