### PR TITLE
Add PyInstaller spec file for standalone executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!packaging/deckslots.spec
 
 # Installer logs
 pip-log.txt

--- a/packaging/deckslots.spec
+++ b/packaging/deckslots.spec
@@ -1,0 +1,19 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("deckslots")  # data/templates/ and data/fonts/
+
+a = Analysis(
+    ["bin/deckslots"],
+    pathex=[],
+    datas=datas,
+    hiddenimports=["deckslots.gui"],  # lazy import in cli/parser.py
+)
+pyz = PYZ(a.pure, a.zipped_data)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    name="deckslots",
+    console=False,
+)


### PR DESCRIPTION
## Summary

Add a PyInstaller hook configuration (`packaging/deckslots.spec`) to enable building a standalone executable from the `deckslots` CLI entrypoint. This allows end users to run the application without requiring a Python installation.

## Changes

- **Added `packaging/deckslots.spec`**: PyInstaller Analysis configuration that:
  - Bundles the `bin/deckslots` entrypoint as the executable root
  - Collects all data files from the `deckslots` package (templates and fonts in `data/`)
  - Declares `deckslots.gui` as a hidden import (lazy-loaded in `cli/parser.py`)
  - Builds a windowed (non-console) executable named `deckslots`

- **Updated `.gitignore`**: Added exception `!packaging/deckslots.spec` to allow this spec file to be tracked in version control (while keeping other `.spec` files ignored, as they are typically generated per-build)

## Implementation Details

The spec file uses PyInstaller's `collect_data_files()` utility to automatically discover and bundle template and font assets, ensuring the packaged executable has access to all required data files without manual path configuration.

https://claude.ai/code/session_01VBopPYpLNXyLvX5QPrsJmE