### PR TITLE
fix: send Accept: application/json in Scryfall bulk-data request

### DIFF
--- a/src/deckslots/scryfall.py
+++ b/src/deckslots/scryfall.py
@@ -72,7 +72,8 @@ def load_index_from_cache(path: Path) -> dict[str, dict] | None:
 def fetch_bulk_data_url() -> str:
     """Fetch the current download URI for the oracle_cards bulk file from Scryfall."""
     api_url = "https://api.scryfall.com/bulk-data/oracle-cards"
-    with urllib.request.urlopen(api_url) as resp:  # noqa: S310
+    req = urllib.request.Request(api_url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
         data = json.loads(resp.read().decode())
     return data["download_uri"]
 

--- a/tests/test_scryfall.py
+++ b/tests/test_scryfall.py
@@ -303,6 +303,65 @@ class TestConfig:
 
 
 # ---------------------------------------------------------------------------
+# fetch_bulk_data_url
+# ---------------------------------------------------------------------------
+
+
+class TestFetchBulkDataUrl:
+    def test_sends_accept_json_header(self, monkeypatch):
+        """Scryfall (via Cloudflare) rejects requests without Accept: application/json."""
+        from deckslots import scryfall
+
+        captured: dict = {}
+
+        def fake_urlopen(req, *args, **kwargs):  # noqa: ARG001
+            captured["req"] = req
+
+            class _R:
+                def read(self_inner):
+                    return json.dumps(
+                        {"download_uri": "https://example.com/oracle.json"}
+                    ).encode()
+
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, *a):
+                    return False
+
+            return _R()
+
+        monkeypatch.setattr(scryfall.urllib.request, "urlopen", fake_urlopen)
+        scryfall.fetch_bulk_data_url()
+
+        req = captured["req"]
+        assert hasattr(req, "get_header"), "urlopen must be called with a Request object"
+        assert req.get_header("Accept") == "application/json"
+
+    def test_returns_download_uri(self, monkeypatch):
+        from deckslots import scryfall
+
+        def fake_urlopen(req, *args, **kwargs):  # noqa: ARG001
+            class _R:
+                def read(self_inner):
+                    return json.dumps(
+                        {"download_uri": "https://example.com/oracle.json"}
+                    ).encode()
+
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, *a):
+                    return False
+
+            return _R()
+
+        monkeypatch.setattr(scryfall.urllib.request, "urlopen", fake_urlopen)
+        url = scryfall.fetch_bulk_data_url()
+        assert url == "https://example.com/oracle.json"
+
+
+# ---------------------------------------------------------------------------
 # Image pipeline (Phase 2)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Scryfall's API (fronted by Cloudflare) started returning HTTP 400 for requests that lack an explicit `Accept` header — Python's `urllib` sends none by default
- Fixed `fetch_bulk_data_url()` in `scryfall.py` to wrap the URL in a `urllib.request.Request` with `Accept: application/json`
- Added two tests to `TestFetchBulkDataUrl`: one asserting the header is sent, one asserting the returned URI is parsed correctly

## Test plan

- [x] `uv run pytest tests/test_scryfall.py::TestFetchBulkDataUrl` — both new tests pass
- [x] `uv run pytest` — full suite green
- [x] Launch `deckslots gui` and confirm status bar shows "Updating card index…" then "Card index ready" instead of the HTTP 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)